### PR TITLE
perf: Allow MoveThreadRunner to generate its own moves

### DIFF
--- a/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/DefaultMultithreadedSolvingEnterpriseService.java
+++ b/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/DefaultMultithreadedSolvingEnterpriseService.java
@@ -17,8 +17,8 @@ import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 public final class DefaultMultithreadedSolvingEnterpriseService implements MultithreadedSolvingEnterpriseService {
     @Override
     public <Solution_> ConstructionHeuristicDecider<Solution_> buildConstructionHeuristic(int moveThreadCount,
-                                                                                          Termination<Solution_> termination, ConstructionHeuristicForager<Solution_> forager,
-                                                                                          EnvironmentMode environmentMode, HeuristicConfigPolicy<Solution_> configPolicy) {
+            Termination<Solution_> termination, ConstructionHeuristicForager<Solution_> forager,
+            EnvironmentMode environmentMode, HeuristicConfigPolicy<Solution_> configPolicy) {
         Integer moveThreadBufferSize = configPolicy.getMoveThreadBufferSize();
         if (moveThreadBufferSize == null) {
             // TODO Verify this is a good default by more meticulous benchmarking on multiple machines and JDK's
@@ -42,8 +42,8 @@ public final class DefaultMultithreadedSolvingEnterpriseService implements Multi
 
     @Override
     public <Solution_> LocalSearchDecider<Solution_> buildLocalSearch(int moveThreadCount, Termination<Solution_> termination,
-                                                                      MoveSelector<Solution_> moveSelector, Acceptor<Solution_> acceptor, LocalSearchForager<Solution_> forager,
-                                                                      EnvironmentMode environmentMode, HeuristicConfigPolicy<Solution_> configPolicy) {
+            MoveSelector<Solution_> moveSelector, Acceptor<Solution_> acceptor, LocalSearchForager<Solution_> forager,
+            EnvironmentMode environmentMode, HeuristicConfigPolicy<Solution_> configPolicy) {
         Integer moveThreadBufferSize = configPolicy.getMoveThreadBufferSize();
         if (moveThreadBufferSize == null) {
             // TODO Verify this is a good default by more meticulous benchmarking on multiple machines and JDK's

--- a/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/DefaultMultithreadedSolvingEnterpriseService.java
+++ b/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/DefaultMultithreadedSolvingEnterpriseService.java
@@ -15,17 +15,15 @@ import ai.timefold.solver.core.impl.solver.termination.Termination;
 import ai.timefold.solver.core.impl.solver.thread.ChildThreadType;
 
 public final class DefaultMultithreadedSolvingEnterpriseService implements MultithreadedSolvingEnterpriseService {
-
     @Override
     public <Solution_> ConstructionHeuristicDecider<Solution_> buildConstructionHeuristic(int moveThreadCount,
-            Termination<Solution_> termination, ConstructionHeuristicForager<Solution_> forager,
-            EnvironmentMode environmentMode, HeuristicConfigPolicy<Solution_> configPolicy) {
+                                                                                          Termination<Solution_> termination, ConstructionHeuristicForager<Solution_> forager,
+                                                                                          EnvironmentMode environmentMode, HeuristicConfigPolicy<Solution_> configPolicy) {
         Integer moveThreadBufferSize = configPolicy.getMoveThreadBufferSize();
         if (moveThreadBufferSize == null) {
             // TODO Verify this is a good default by more meticulous benchmarking on multiple machines and JDK's
             // If it's too low, move threads will need to wait on the buffer, which hurts performance
-            // If it's too high, more moves are selected that aren't foraged
-            moveThreadBufferSize = 10;
+            moveThreadBufferSize = 64;
         }
         ThreadFactory threadFactory = configPolicy.buildThreadFactory(ChildThreadType.MOVE_THREAD);
         int selectedMoveBufferSize = moveThreadCount * moveThreadBufferSize;
@@ -44,14 +42,13 @@ public final class DefaultMultithreadedSolvingEnterpriseService implements Multi
 
     @Override
     public <Solution_> LocalSearchDecider<Solution_> buildLocalSearch(int moveThreadCount, Termination<Solution_> termination,
-            MoveSelector<Solution_> moveSelector, Acceptor<Solution_> acceptor, LocalSearchForager<Solution_> forager,
-            EnvironmentMode environmentMode, HeuristicConfigPolicy<Solution_> configPolicy) {
+                                                                      MoveSelector<Solution_> moveSelector, Acceptor<Solution_> acceptor, LocalSearchForager<Solution_> forager,
+                                                                      EnvironmentMode environmentMode, HeuristicConfigPolicy<Solution_> configPolicy) {
         Integer moveThreadBufferSize = configPolicy.getMoveThreadBufferSize();
         if (moveThreadBufferSize == null) {
             // TODO Verify this is a good default by more meticulous benchmarking on multiple machines and JDK's
             // If it's too low, move threads will need to wait on the buffer, which hurts performance
-            // If it's too high, more moves are selected that aren't foraged
-            moveThreadBufferSize = 10;
+            moveThreadBufferSize = 64;
         }
         ThreadFactory threadFactory = configPolicy.buildThreadFactory(ChildThreadType.MOVE_THREAD);
         int selectedMoveBufferSize = moveThreadCount * moveThreadBufferSize;

--- a/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/MoveThreadRunner.java
+++ b/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/MoveThreadRunner.java
@@ -1,6 +1,8 @@
 package ai.timefold.solver.enterprise.core.multithreaded;
 
-import java.util.concurrent.*;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceArray;
@@ -79,6 +81,7 @@ final class MoveThreadRunner<Solution_, Score_ extends Score<Score_>> implements
                                 iteratorReference.get(generatedMoveIndex % iteratorReference.length());
                         synchronized (neverEndingMoveGenerator) {
                             generatedMoveIndex = neverEndingMoveGenerator.getNextMoveIndex();
+                            resultQueue.reserveSpaceForMove(generatedMoveIndex);
                             operation = new MoveEvaluationOperation<>(stepIndex, generatedMoveIndex,
                                     neverEndingMoveGenerator.generateNextMove());
                         }

--- a/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/MoveThreadRunner.java
+++ b/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/MoveThreadRunner.java
@@ -65,8 +65,8 @@ final class MoveThreadRunner<Solution_, Score_ extends Score<Score_>> implements
     @Override
     public void run() {
         int generatedMoveIndex = -1;
+        int stepIndex = -1;
         try {
-            int stepIndex = -1;
             Score_ lastStepScore = null;
             resultQueue.waitForDecider();
             // Wait for the iteratorLock to be available before entering the loop
@@ -81,9 +81,15 @@ final class MoveThreadRunner<Solution_, Score_ extends Score<Score_>> implements
                                 iteratorReference.get(generatedMoveIndex % iteratorReference.length());
                         synchronized (neverEndingMoveGenerator) {
                             generatedMoveIndex = neverEndingMoveGenerator.getNextMoveIndex();
+                            LOGGER.trace(
+                                    "{}            Move thread ({}) step: step index ({}), move index ({}) Generating move.",
+                                    logIndentation, moveThreadIndex, stepIndex, generatedMoveIndex);
                             resultQueue.reserveSpaceForMove(generatedMoveIndex);
                             operation = new MoveEvaluationOperation<>(stepIndex, generatedMoveIndex,
                                     neverEndingMoveGenerator.generateNextMove());
+                            LOGGER.trace(
+                                    "{}            Move thread ({}) step: step index ({}), move index ({}) Generated move.",
+                                    logIndentation, moveThreadIndex, stepIndex, generatedMoveIndex);
                         }
                     }
                 } catch (InterruptedException e) {
@@ -147,7 +153,15 @@ final class MoveThreadRunner<Solution_, Score_ extends Score<Score_>> implements
                                 + moveEvaluationOperation.getStepIndex() + ") with moveIndex ("
                                 + moveIndex + ").");
                     }
-                    Move<Solution_> move = moveEvaluationOperation.getMove().rebase(scoreDirector);
+                    Move<Solution_> move = moveEvaluationOperation.getMove();
+                    if (move == null) {
+                        LOGGER.trace(
+                                "{}            Move thread ({}) evaluation: step index ({}), move index ({}), iterator exhausted.",
+                                logIndentation, moveThreadIndex, stepIndex, moveIndex);
+                        resultQueue.reportIteratorExhausted(stepIndex, moveIndex);
+                        continue;
+                    }
+                    move = move.rebase(scoreDirector);
                     if (evaluateDoable && !move.isMoveDoable(scoreDirector)) {
                         LOGGER.trace("{}            Move thread ({}) evaluation: step index ({}), move index ({}), not doable.",
                                 logIndentation, moveThreadIndex, stepIndex, moveIndex);
@@ -173,7 +187,8 @@ final class MoveThreadRunner<Solution_, Score_ extends Score<Score_>> implements
             // in the resultQueue in order to be propagated to the solver thread.
             LOGGER.trace("{}            Move thread ({}) exception that will be propagated to the solver thread.",
                     logIndentation, moveThreadIndex, throwable);
-            resultQueue.addExceptionThrown(generatedMoveIndex == -1 ? moveThreadIndex : generatedMoveIndex, throwable);
+            resultQueue.addExceptionThrown(moveThreadIndex, generatedMoveIndex == -1 ? moveThreadIndex : generatedMoveIndex,
+                    throwable);
         } finally {
             if (scoreDirector != null) {
                 scoreDirector.close();

--- a/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/MultiThreadedConstructionHeuristicDecider.java
+++ b/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/MultiThreadedConstructionHeuristicDecider.java
@@ -101,6 +101,7 @@ final class MultiThreadedConstructionHeuristicDecider<Solution_> extends Constru
         for (int i = 0; i < moveThreadCount; i++) {
             operationQueue.add(destroyOperation);
         }
+        resultQueue.endPhase();
         shutdownMoveThreads();
         long childThreadsScoreCalculationCount = 0;
         for (MoveThreadRunner<Solution_, ?> moveThreadRunner : moveThreadRunnerList) {

--- a/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/MultiThreadedConstructionHeuristicDecider.java
+++ b/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/MultiThreadedConstructionHeuristicDecider.java
@@ -98,6 +98,7 @@ final class MultiThreadedConstructionHeuristicDecider<Solution_> extends Constru
         // Don't clear the operationsQueue to avoid moveThreadBarrier deadlock:
         // The MoveEvaluationOperations are already cleared and the new ApplyStepOperation isn't added yet.
         DestroyOperation<Solution_> destroyOperation = new DestroyOperation<>();
+        // Setting over here does not work, but incrementAndGet does
         for (int i = 0; i < moveThreadCount; i++) {
             operationQueue.add(destroyOperation);
         }
@@ -209,6 +210,10 @@ final class MultiThreadedConstructionHeuristicDecider<Solution_> extends Constru
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             return true;
+        }
+        if (result == null) {
+            stepScope.getPhaseScope().getSolverScope().checkYielding();
+            return termination.isPhaseTerminated(stepScope.getPhaseScope());
         }
         if (stepIndex != result.getStepIndex()) {
             throw new IllegalStateException("Impossible situation: the solverThread's stepIndex (" + stepIndex

--- a/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/MultiThreadedConstructionHeuristicDecider.java
+++ b/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/MultiThreadedConstructionHeuristicDecider.java
@@ -1,15 +1,11 @@
 package ai.timefold.solver.enterprise.core.multithreaded;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.score.Score;
@@ -41,6 +37,8 @@ final class MultiThreadedConstructionHeuristicDecider<Solution_> extends Constru
     private BlockingQueue<MoveThreadOperation<Solution_>> operationQueue;
     private OrderByMoveIndexBlockingQueue<Solution_> resultQueue;
     private CyclicBarrier moveThreadBarrier;
+    private AtomicInteger moveIndex;
+    private AtomicReferenceArray<NeverEndingMoveGenerator<Solution_>> iteratorReference;
     private ExecutorService executor;
     private List<MoveThreadRunner<Solution_, ?>> moveThreadRunnerList;
 
@@ -71,15 +69,18 @@ final class MultiThreadedConstructionHeuristicDecider<Solution_> extends Constru
         // Capacity: number of moves in circulation + number of setup xor step operations + number of destroy operations
         operationQueue = new ArrayBlockingQueue<>(selectedMoveBufferSize + moveThreadCount + moveThreadCount);
         // Capacity: number of moves in circulation + number of exception handling results
-        resultQueue = new OrderByMoveIndexBlockingQueue<>(selectedMoveBufferSize + moveThreadCount);
+        resultQueue = new OrderByMoveIndexBlockingQueue<>(moveThreadCount, selectedMoveBufferSize + moveThreadCount);
         moveThreadBarrier = new CyclicBarrier(moveThreadCount);
+        moveIndex = new AtomicInteger(0);
+        iteratorReference = new AtomicReferenceArray<>(moveThreadCount);
         InnerScoreDirector<Solution_, ?> scoreDirector = phaseScope.getScoreDirector();
         executor = createThreadPoolExecutor();
         moveThreadRunnerList = new ArrayList<>(moveThreadCount);
+
         for (int moveThreadIndex = 0; moveThreadIndex < moveThreadCount; moveThreadIndex++) {
             MoveThreadRunner<Solution_, ?> moveThreadRunner = new MoveThreadRunner<>(
                     logIndentation, moveThreadIndex, false,
-                    operationQueue, resultQueue, moveThreadBarrier,
+                    operationQueue, resultQueue, moveThreadBarrier, moveIndex, iteratorReference,
                     assertMoveScoreFromScratch, assertExpectedUndoMoveScore,
                     assertStepScoreFromScratch, assertExpectedStepScore, assertShadowVariablesAreNotStaleAfterStep);
             moveThreadRunnerList.add(moveThreadRunner);
@@ -129,34 +130,33 @@ final class MultiThreadedConstructionHeuristicDecider<Solution_> extends Constru
     @Override
     public void decideNextStep(ConstructionHeuristicStepScope<Solution_> stepScope, Placement<Solution_> placement) {
         int stepIndex = stepScope.getStepIndex();
-        resultQueue.startNextStep(stepIndex);
 
         int selectMoveIndex = 0;
-        int movesInPlay = 0;
-        Iterator<Move<Solution_>> moveIterator = placement.iterator();
-        do {
-            boolean hasNextMove = moveIterator.hasNext();
-            // First fill the buffer so move evaluation can run freely in parallel
-            // For reproducibility, the selectedMoveBufferSize always need to be entirely selected,
-            // even if some of those moves won't end up being evaluated or foraged
-            if (movesInPlay > 0 && (selectMoveIndex >= selectedMoveBufferSize || !hasNextMove)) {
-                if (forageResult(stepScope, stepIndex)) {
-                    break;
-                }
-                movesInPlay--;
+        AtomicLong hasNextRemaining;
+        if (false) {
+            // TODO: Code for split move selectors
+        } else {
+            hasNextRemaining = new AtomicLong(1);
+            SharedNeverEndingMoveGenerator<Solution_> sharedIterator = new SharedNeverEndingMoveGenerator<>(hasNextRemaining, resultQueue, placement.iterator());
+            for (int i = 0; i < moveThreadCount; i++) {
+                iteratorReference.set(i, sharedIterator);
             }
-            if (hasNextMove) {
-                Move<Solution_> move = moveIterator.next();
-                operationQueue.add(new MoveEvaluationOperation<>(stepIndex, selectMoveIndex, move));
-                selectMoveIndex++;
-                movesInPlay++;
+        }
+        moveIndex.set(0);
+        resultQueue.startNextStep(stepIndex);
+        while (selectMoveIndex < moveIndex.get() || !resultQueue.checkIfBlocking()){
+            if (forageResult(stepScope, stepIndex)) {
+                break;
             }
-        } while (movesInPlay > 0);
+            selectMoveIndex++;
+        }
 
         // Do not evaluate the remaining selected moves for this step that haven't started evaluation yet
-        operationQueue.clear();
+        resultQueue.blockMoveThreads();
+
         pickMove(stepScope);
         // Start doing the step on every move thread. Don't wait for the stepEnded() event.
+        resultQueue.deciderSyncOnEnd();
         if (stepScope.getStep() != null) {
             InnerScoreDirector<Solution_, ?> scoreDirector = stepScope.getScoreDirector();
             if (scoreDirector.requiresFlushing() && stepIndex % 100 == 99) {

--- a/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/MultiThreadedLocalSearchDecider.java
+++ b/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/MultiThreadedLocalSearchDecider.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.enterprise.core.multithreaded;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -134,29 +135,48 @@ final class MultiThreadedLocalSearchDecider<Solution_> extends LocalSearchDecide
 
         int selectMoveIndex = 0;
         AtomicLong hasNextRemaining;
+        Semaphore waitForDeciderSemaphore;
+        Iterator<Move<Solution_>> sharedIterator;
+        boolean useSemaphore = true;
         if (false) {
             // TODO: Code for split move selectors
         } else {
             hasNextRemaining = new AtomicLong(1);
-            SharedNeverEndingMoveGenerator<Solution_> sharedIterator = new SharedNeverEndingMoveGenerator<>(hasNextRemaining, resultQueue, moveSelector.iterator());
+            waitForDeciderSemaphore = new Semaphore(selectedMoveBufferSize);
+            sharedIterator = moveSelector.iterator();
+            SharedNeverEndingMoveGenerator<Solution_> sharedGenerator = new SharedNeverEndingMoveGenerator<>(hasNextRemaining,
+                    resultQueue, sharedIterator, waitForDeciderSemaphore);
             for (int i = 0; i < moveThreadCount; i++) {
-                iteratorReference.set(i, sharedIterator);
+                iteratorReference.set(i, sharedGenerator);
             }
         }
         moveIndex.set(0);
         resultQueue.startNextStep(stepIndex);
-        while (selectMoveIndex < moveIndex.get() || !resultQueue.checkIfBlocking()){
+        while (selectMoveIndex < moveIndex.get() || !resultQueue.checkIfBlocking()) {
             if (forageResult(stepScope, stepIndex)) {
                 break;
             }
             selectMoveIndex++;
+            if (useSemaphore && (selectMoveIndex % selectedMoveBufferSize) == 0 && !resultQueue.checkIfBlocking()) {
+                waitForDeciderSemaphore.release(selectedMoveBufferSize);
+            }
         }
 
         // Do not evaluate the remaining selected moves for this step that haven't started evaluation yet
         resultQueue.blockMoveThreads();
+
         pickMove(stepScope);
         // Start doing the step on every move thread. Don't wait for the stepEnded() event.
         resultQueue.deciderSyncOnEnd();
+        if (useSemaphore) {
+            for (int i = 0; i < waitForDeciderSemaphore.availablePermits(); i++) {
+                if (!sharedIterator.hasNext()) {
+                    break;
+                }
+                sharedIterator.next();
+            }
+        }
+
         if (stepScope.getStep() != null) {
             InnerScoreDirector<Solution_, ?> scoreDirector = stepScope.getScoreDirector();
             if (scoreDirector.requiresFlushing() && stepIndex % 100 == 99) {

--- a/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/MultiThreadedLocalSearchDecider.java
+++ b/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/MultiThreadedLocalSearchDecider.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceArray;
@@ -135,6 +136,7 @@ final class MultiThreadedLocalSearchDecider<Solution_> extends LocalSearchDecide
 
         int selectMoveIndex = 0;
         AtomicLong hasNextRemaining;
+        AtomicBoolean hasNextShared;
         Semaphore waitForDeciderSemaphore;
         Iterator<Move<Solution_>> sharedIterator;
         boolean useSemaphore = true;
@@ -142,10 +144,11 @@ final class MultiThreadedLocalSearchDecider<Solution_> extends LocalSearchDecide
             // TODO: Code for split move selectors
         } else {
             hasNextRemaining = new AtomicLong(1);
+            hasNextShared = new AtomicBoolean(true);
             waitForDeciderSemaphore = new Semaphore(selectedMoveBufferSize);
             sharedIterator = moveSelector.iterator();
             SharedNeverEndingMoveGenerator<Solution_> sharedGenerator = new SharedNeverEndingMoveGenerator<>(hasNextRemaining,
-                    resultQueue, sharedIterator, waitForDeciderSemaphore);
+                    resultQueue, sharedIterator, waitForDeciderSemaphore, hasNextShared);
             for (int i = 0; i < moveThreadCount; i++) {
                 iteratorReference.set(i, sharedGenerator);
             }
@@ -163,13 +166,19 @@ final class MultiThreadedLocalSearchDecider<Solution_> extends LocalSearchDecide
         }
 
         // Do not evaluate the remaining selected moves for this step that haven't started evaluation yet
+        int remainingPermits = 0;
         resultQueue.blockMoveThreads();
+        if (useSemaphore) {
+            remainingPermits = waitForDeciderSemaphore.drainPermits();
+            hasNextShared.setRelease(false);
+            waitForDeciderSemaphore.release(selectedMoveBufferSize);
+        }
 
         pickMove(stepScope);
         // Start doing the step on every move thread. Don't wait for the stepEnded() event.
         resultQueue.deciderSyncOnEnd();
         if (useSemaphore) {
-            for (int i = 0; i < waitForDeciderSemaphore.availablePermits(); i++) {
+            for (int i = 0; i < remainingPermits; i++) {
                 if (!sharedIterator.hasNext()) {
                     break;
                 }

--- a/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/MultiThreadedLocalSearchDecider.java
+++ b/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/MultiThreadedLocalSearchDecider.java
@@ -102,6 +102,7 @@ final class MultiThreadedLocalSearchDecider<Solution_> extends LocalSearchDecide
         for (int i = 0; i < moveThreadCount; i++) {
             operationQueue.add(destroyOperation);
         }
+        resultQueue.endPhase();
         shutdownMoveThreads();
         long childThreadsScoreCalculationCount = 0;
         for (MoveThreadRunner<Solution_, ?> moveThreadRunner : moveThreadRunnerList) {

--- a/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/MultiThreadedLocalSearchDecider.java
+++ b/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/MultiThreadedLocalSearchDecider.java
@@ -1,15 +1,11 @@
 package ai.timefold.solver.enterprise.core.multithreaded;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.score.Score;
@@ -42,6 +38,8 @@ final class MultiThreadedLocalSearchDecider<Solution_> extends LocalSearchDecide
     private BlockingQueue<MoveThreadOperation<Solution_>> operationQueue;
     private OrderByMoveIndexBlockingQueue<Solution_> resultQueue;
     private CyclicBarrier moveThreadBarrier;
+    private AtomicInteger moveIndex;
+    private AtomicReferenceArray<NeverEndingMoveGenerator<Solution_>> iteratorReference;
     private ExecutorService executor;
     private List<MoveThreadRunner<Solution_, ?>> moveThreadRunnerList;
 
@@ -72,15 +70,18 @@ final class MultiThreadedLocalSearchDecider<Solution_> extends LocalSearchDecide
         // Capacity: number of moves in circulation + number of setup xor step operations + number of destroy operations
         operationQueue = new ArrayBlockingQueue<>(selectedMoveBufferSize + moveThreadCount + moveThreadCount);
         // Capacity: number of moves in circulation + number of exception handling results
-        resultQueue = new OrderByMoveIndexBlockingQueue<>(selectedMoveBufferSize + moveThreadCount);
+        resultQueue = new OrderByMoveIndexBlockingQueue<>(moveThreadCount, selectedMoveBufferSize + moveThreadCount);
         moveThreadBarrier = new CyclicBarrier(moveThreadCount);
+        moveIndex = new AtomicInteger(0);
+        iteratorReference = new AtomicReferenceArray<>(moveThreadCount);
         InnerScoreDirector<Solution_, ?> scoreDirector = phaseScope.getScoreDirector();
         executor = createThreadPoolExecutor();
         moveThreadRunnerList = new ArrayList<>(moveThreadCount);
+
         for (int moveThreadIndex = 0; moveThreadIndex < moveThreadCount; moveThreadIndex++) {
             MoveThreadRunner<Solution_, ?> moveThreadRunner = new MoveThreadRunner<>(
-                    logIndentation, moveThreadIndex, true,
-                    operationQueue, resultQueue, moveThreadBarrier,
+                    logIndentation, moveThreadIndex, false,
+                    operationQueue, resultQueue, moveThreadBarrier, moveIndex, iteratorReference,
                     assertMoveScoreFromScratch, assertExpectedUndoMoveScore,
                     assertStepScoreFromScratch, assertExpectedStepScore, assertShadowVariablesAreNotStaleAfterStep);
             moveThreadRunnerList.add(moveThreadRunner);
@@ -130,34 +131,32 @@ final class MultiThreadedLocalSearchDecider<Solution_> extends LocalSearchDecide
     @Override
     public void decideNextStep(LocalSearchStepScope<Solution_> stepScope) {
         int stepIndex = stepScope.getStepIndex();
-        resultQueue.startNextStep(stepIndex);
 
         int selectMoveIndex = 0;
-        int movesInPlay = 0;
-        Iterator<Move<Solution_>> moveIterator = moveSelector.iterator();
-        do {
-            boolean hasNextMove = moveIterator.hasNext();
-            // First fill the buffer so move evaluation can run freely in parallel
-            // For reproducibility, the selectedMoveBufferSize always need to be entirely selected,
-            // even if some of those moves won't end up being evaluated or foraged
-            if (movesInPlay > 0 && (selectMoveIndex >= selectedMoveBufferSize || !hasNextMove)) {
-                if (forageResult(stepScope, stepIndex)) {
-                    break;
-                }
-                movesInPlay--;
+        AtomicLong hasNextRemaining;
+        if (false) {
+            // TODO: Code for split move selectors
+        } else {
+            hasNextRemaining = new AtomicLong(1);
+            SharedNeverEndingMoveGenerator<Solution_> sharedIterator = new SharedNeverEndingMoveGenerator<>(hasNextRemaining, resultQueue, moveSelector.iterator());
+            for (int i = 0; i < moveThreadCount; i++) {
+                iteratorReference.set(i, sharedIterator);
             }
-            if (hasNextMove) {
-                Move<Solution_> move = moveIterator.next();
-                operationQueue.add(new MoveEvaluationOperation<>(stepIndex, selectMoveIndex, move));
-                selectMoveIndex++;
-                movesInPlay++;
+        }
+        moveIndex.set(0);
+        resultQueue.startNextStep(stepIndex);
+        while (selectMoveIndex < moveIndex.get() || !resultQueue.checkIfBlocking()){
+            if (forageResult(stepScope, stepIndex)) {
+                break;
             }
-        } while (movesInPlay > 0);
+            selectMoveIndex++;
+        }
 
         // Do not evaluate the remaining selected moves for this step that haven't started evaluation yet
-        operationQueue.clear();
+        resultQueue.blockMoveThreads();
         pickMove(stepScope);
         // Start doing the step on every move thread. Don't wait for the stepEnded() event.
+        resultQueue.deciderSyncOnEnd();
         if (stepScope.getStep() != null) {
             InnerScoreDirector<Solution_, ?> scoreDirector = stepScope.getScoreDirector();
             if (scoreDirector.requiresFlushing() && stepIndex % 100 == 99) {
@@ -166,8 +165,8 @@ final class MultiThreadedLocalSearchDecider<Solution_> extends LocalSearchDecide
                 scoreDirector.calculateScore();
             }
             // Increase stepIndex by 1, because it's a preliminary action
-            ApplyStepOperation<Solution_, ?> stepOperation =
-                    new ApplyStepOperation<>(stepIndex + 1, stepScope.getStep(), (Score) stepScope.getScore());
+            ApplyStepOperation<Solution_, ?> stepOperation = new ApplyStepOperation<>(stepIndex + 1,
+                    stepScope.getStep(), (Score) stepScope.getScore());
             for (int i = 0; i < moveThreadCount; i++) {
                 operationQueue.add(stepOperation);
             }

--- a/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/NeverEndingMoveGenerator.java
+++ b/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/NeverEndingMoveGenerator.java
@@ -1,0 +1,7 @@
+package ai.timefold.solver.enterprise.core.multithreaded;
+
+import ai.timefold.solver.core.impl.heuristic.move.Move;
+
+sealed interface NeverEndingMoveGenerator<Solution_> permits SharedNeverEndingMoveGenerator {
+    Move<Solution_> generateNextMove();
+}

--- a/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/NeverEndingMoveGenerator.java
+++ b/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/NeverEndingMoveGenerator.java
@@ -4,4 +4,6 @@ import ai.timefold.solver.core.impl.heuristic.move.Move;
 
 sealed interface NeverEndingMoveGenerator<Solution_> permits SharedNeverEndingMoveGenerator {
     Move<Solution_> generateNextMove();
+
+    int getNextMoveIndex();
 }

--- a/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/OrderByMoveIndexBlockingQueue.java
+++ b/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/OrderByMoveIndexBlockingQueue.java
@@ -216,7 +216,6 @@ final class OrderByMoveIndexBlockingQueue<Solution_> {
         }
     }
 
-
     public boolean checkIfBlocking() {
         return syncDeciderAndMoveThreads.getAcquire();
     }

--- a/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/OrderByMoveIndexBlockingQueue.java
+++ b/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/OrderByMoveIndexBlockingQueue.java
@@ -38,6 +38,10 @@ final class OrderByMoveIndexBlockingQueue<Solution_> {
         }
     }
 
+    public int getMoveThreadCount() {
+        return syncDeciderAndMoveThreadsStartBarrier.getParties() - 1;
+    }
+
     /**
      * Not thread-safe. Can only be called from the solver thread.
      *
@@ -159,6 +163,25 @@ final class OrderByMoveIndexBlockingQueue<Solution_> {
         }
     }
 
+    public void reportIteratorExhausted(int stepIndex, int moveIndex) {
+        int ringBufferSlot = moveIndex % moveResultRingBuffer.length();
+        if (stepIndex != filterStepIndex) {
+            // Discard element from previous step
+            spaceAvailableInRingBufferSemaphores[ringBufferSlot].release();
+            return;
+        }
+        moveResultRingBuffer.setRelease(ringBufferSlot, null);
+        resultAvailableInRingBufferSemaphores[ringBufferSlot].release();
+        if (syncDeciderAndMoveThreads.getAcquire()) {
+            try {
+                syncDeciderAndMoveThreadsEndBarrier.await();
+                syncDeciderAndMoveThreadsStartBarrier.await();
+            } catch (InterruptedException | BrokenBarrierException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
     /**
      * This method is thread-safe. It can be called from any move thread.
      * Previous results (that haven't been consumed yet), will still be returned during iteration
@@ -168,11 +191,12 @@ final class OrderByMoveIndexBlockingQueue<Solution_> {
      * @param moveIndex the index of the move that generated the exception
      * @param throwable never null
      */
-    public void addExceptionThrown(int moveIndex, Throwable throwable) {
-        MoveResult<Solution_> result = new MoveResult<>(moveIndex, throwable);
+    public void addExceptionThrown(int moveThreadIndex, int moveIndex, Throwable throwable) {
+        MoveResult<Solution_> result = new MoveResult<>(moveThreadIndex, moveIndex, throwable);
         int ringBufferSlot = moveIndex % moveResultRingBuffer.length();
         moveResultRingBuffer.setRelease(ringBufferSlot, result);
         resultAvailableInRingBufferSemaphores[ringBufferSlot].release();
+        syncDeciderAndMoveThreadsEndBarrier.reset();
     }
 
     /**
@@ -190,6 +214,10 @@ final class OrderByMoveIndexBlockingQueue<Solution_> {
         MoveResult<Solution_> result = moveResultRingBuffer.getAcquire(ringBufferIndex);
         moveResultRingBuffer.setRelease(ringBufferIndex, null);
         spaceAvailableInRingBufferSemaphores[ringBufferIndex].release();
+        if (result == null) {
+            // iterator exhausted
+            return null;
+        }
         // If 2 exceptions are added from different threads concurrently, either one could end up first.
         // This is a known deviation from 100% reproducibility, that never occurs in a success scenario.
         if (result.hasThrownException()) {
@@ -222,7 +250,18 @@ final class OrderByMoveIndexBlockingQueue<Solution_> {
                 semaphore.release(threadCount);
             }
             syncDeciderAndMoveThreadsEndBarrier.await();
-        } catch (InterruptedException | BrokenBarrierException e) {
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        } catch (BrokenBarrierException e) {
+            for (int i = 0; i < moveResultRingBuffer.length(); i++) {
+                MoveResult<Solution_> result = moveResultRingBuffer.getAcquire(i);
+                if (result != null && result.hasThrownException()) {
+                    throw new IllegalStateException("The move thread with moveThreadIndex ("
+                            + result.getMoveThreadIndex() + ") has thrown an exception."
+                            + " Relayed here in the parent thread.",
+                            result.getThrowable());
+                }
+            }
             throw new RuntimeException(e);
         }
     }
@@ -252,10 +291,10 @@ final class OrderByMoveIndexBlockingQueue<Solution_> {
             this.throwable = null;
         }
 
-        public MoveResult(int moveThreadIndex, Throwable throwable) {
+        public MoveResult(int moveThreadIndex, int moveIndex, Throwable throwable) {
             this.moveThreadIndex = moveThreadIndex;
             this.stepIndex = -1;
-            this.moveIndex = -1;
+            this.moveIndex = moveIndex;
             this.move = null;
             this.moveDoable = false;
             this.score = null;

--- a/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/OrderByMoveIndexBlockingQueue.java
+++ b/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/OrderByMoveIndexBlockingQueue.java
@@ -1,24 +1,38 @@
 package ai.timefold.solver.enterprise.core.multithreaded;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.impl.heuristic.move.Move;
 
 final class OrderByMoveIndexBlockingQueue<Solution_> {
+    private final AtomicReferenceArray<MoveResult<Solution_>> moveResultRingBuffer;
 
-    private final BlockingQueue<MoveResult<Solution_>> innerQueue;
-    private final Map<Integer, MoveResult<Solution_>> backlog;
+    // Semaphores are reused/never change, and thus don't need to be in an AtomicReferenceArray
+    private final Semaphore[] spaceAvailableInRingBufferSemaphores;
+    private final Semaphore[] resultAvailableInRingBufferSemaphores;
+    private final CyclicBarrier syncDeciderAndMoveThreadsStartBarrier;
+    private final CyclicBarrier syncDeciderAndMoveThreadsEndBarrier;
+    private final AtomicBoolean syncDeciderAndMoveThreads;
 
     private int filterStepIndex = Integer.MIN_VALUE;
     private int nextMoveIndex = Integer.MIN_VALUE;
 
-    public OrderByMoveIndexBlockingQueue(int capacity) {
-        innerQueue = new ArrayBlockingQueue<>(capacity);
-        backlog = new HashMap<>(capacity);
+    public OrderByMoveIndexBlockingQueue(int threadCount, int capacity) {
+        // all move threads + decider
+        syncDeciderAndMoveThreadsStartBarrier = new CyclicBarrier(threadCount + 1);
+        syncDeciderAndMoveThreadsEndBarrier = new CyclicBarrier(threadCount + 1);
+        syncDeciderAndMoveThreads = new AtomicBoolean(false);
+
+        moveResultRingBuffer = new AtomicReferenceArray<>(capacity);
+        spaceAvailableInRingBufferSemaphores = new Semaphore[capacity];
+        resultAvailableInRingBufferSemaphores = new Semaphore[capacity];
+        for (int i = 0; i < capacity; i++) {
+            spaceAvailableInRingBufferSemaphores[i] = new Semaphore(1);
+            resultAvailableInRingBufferSemaphores[i] = new Semaphore(0);
+        }
     }
 
     /**
@@ -27,24 +41,43 @@ final class OrderByMoveIndexBlockingQueue<Solution_> {
      * @param stepIndex at least 0
      */
     public void startNextStep(int stepIndex) {
-        synchronized (this) {
-            if (filterStepIndex >= stepIndex) {
-                throw new IllegalStateException("The old filterStepIndex (" + filterStepIndex
-                        + ") must be less than the stepIndex (" + stepIndex + ")");
+        if (filterStepIndex >= stepIndex) {
+            throw new IllegalStateException("The old filterStepIndex (" + filterStepIndex
+                    + ") must be less than the stepIndex (" + stepIndex + ")");
+        }
+        filterStepIndex = stepIndex;
+        MoveResult<Solution_> exceptionResult = null;
+        for (int i = 0; i < moveResultRingBuffer.length(); i++) {
+            exceptionResult = moveResultRingBuffer.get(i);
+            if (exceptionResult != null && exceptionResult.hasThrownException()) {
+                break;
+            } else {
+                exceptionResult = null;
             }
-            filterStepIndex = stepIndex;
-            MoveResult<Solution_> exceptionResult = innerQueue.stream().filter(MoveResult::hasThrownException)
-                    .findFirst().orElse(null);
-            if (exceptionResult != null) {
-                throw new IllegalStateException("The move thread with moveThreadIndex ("
-                        + exceptionResult.getMoveThreadIndex() + ") has thrown an exception."
-                        + " Relayed here in the parent thread.",
-                        exceptionResult.getThrowable());
-            }
-            innerQueue.clear();
+        }
+        if (exceptionResult != null) {
+            throw new IllegalStateException("The move thread with moveThreadIndex ("
+                    + exceptionResult.getMoveThreadIndex() + ") has thrown an exception."
+                    + " Relayed here in the parent thread.",
+                    exceptionResult.getThrowable());
+        }
+        for (int i = 0; i < moveResultRingBuffer.length(); i++) {
+            moveResultRingBuffer.setRelease(i, null);
+            resultAvailableInRingBufferSemaphores[i].drainPermits();
+        }
+
+        for (Semaphore spaceAvailableInRingBufferSemaphore : spaceAvailableInRingBufferSemaphores) {
+            // make each semaphore have exactly 1 permit available
+            spaceAvailableInRingBufferSemaphore.drainPermits();
+            spaceAvailableInRingBufferSemaphore.release(1);
         }
         nextMoveIndex = 0;
-        backlog.clear();
+        syncDeciderAndMoveThreads.setRelease(false);
+        try {
+            syncDeciderAndMoveThreadsStartBarrier.await();
+        } catch (InterruptedException | BrokenBarrierException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
@@ -57,13 +90,27 @@ final class OrderByMoveIndexBlockingQueue<Solution_> {
      * @see BlockingQueue#add(Object)
      */
     public void addUndoableMove(int moveThreadIndex, int stepIndex, int moveIndex, Move<Solution_> move) {
+        int ringBufferSlot = moveIndex % moveResultRingBuffer.length();
         MoveResult<Solution_> result = new MoveResult<>(moveThreadIndex, stepIndex, moveIndex, move, false, null);
-        synchronized (this) {
-            if (result.getStepIndex() != filterStepIndex) {
-                // Discard element from previous step
-                return;
+        try {
+            spaceAvailableInRingBufferSemaphores[ringBufferSlot].acquire();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        if (result.getStepIndex() != filterStepIndex) {
+            // Discard element from previous step
+            spaceAvailableInRingBufferSemaphores[ringBufferSlot].release();
+            return;
+        }
+        moveResultRingBuffer.setRelease(ringBufferSlot, result);
+        resultAvailableInRingBufferSemaphores[ringBufferSlot].release();
+        if (syncDeciderAndMoveThreads.getAcquire()) {
+            try {
+                syncDeciderAndMoveThreadsEndBarrier.await();
+                syncDeciderAndMoveThreadsStartBarrier.await();
+            } catch (InterruptedException | BrokenBarrierException e) {
+                throw new RuntimeException(e);
             }
-            innerQueue.add(result);
         }
     }
 
@@ -78,13 +125,27 @@ final class OrderByMoveIndexBlockingQueue<Solution_> {
      * @see BlockingQueue#add(Object)
      */
     public void addMove(int moveThreadIndex, int stepIndex, int moveIndex, Move<Solution_> move, Score score) {
+        int ringBufferSlot = moveIndex % moveResultRingBuffer.length();
         MoveResult<Solution_> result = new MoveResult<>(moveThreadIndex, stepIndex, moveIndex, move, true, score);
-        synchronized (this) {
-            if (result.getStepIndex() != filterStepIndex) {
-                // Discard element from previous step
-                return;
+        try {
+            spaceAvailableInRingBufferSemaphores[ringBufferSlot].acquire();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        if (result.getStepIndex() != filterStepIndex) {
+            // Discard element from previous step
+            spaceAvailableInRingBufferSemaphores[ringBufferSlot].release();
+            return;
+        }
+        moveResultRingBuffer.setRelease(ringBufferSlot, result);
+        resultAvailableInRingBufferSemaphores[ringBufferSlot].release();
+        if (syncDeciderAndMoveThreads.getAcquire()) {
+            try {
+                syncDeciderAndMoveThreadsEndBarrier.await();
+                syncDeciderAndMoveThreadsStartBarrier.await();
+            } catch (InterruptedException | BrokenBarrierException e) {
+                throw new RuntimeException(e);
             }
-            innerQueue.add(result);
         }
     }
 
@@ -94,14 +155,19 @@ final class OrderByMoveIndexBlockingQueue<Solution_> {
      * before the iteration throws an exception,
      * unless there's a lower moveIndex that isn't in the queue yet.
      *
-     * @param moveThreadIndex {@code 0 <= moveThreadIndex < moveThreadCount}
+     * @param moveIndex the index of the move that generated the exception
      * @param throwable never null
      */
-    public void addExceptionThrown(int moveThreadIndex, Throwable throwable) {
-        MoveResult<Solution_> result = new MoveResult<>(moveThreadIndex, throwable);
-        synchronized (this) {
-            innerQueue.add(result);
+    public void addExceptionThrown(int moveIndex, Throwable throwable) {
+        MoveResult<Solution_> result = new MoveResult<>(moveIndex, throwable);
+        int ringBufferSlot = moveIndex % moveResultRingBuffer.length();
+        try {
+            spaceAvailableInRingBufferSemaphores[ringBufferSlot].acquire();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
         }
+        moveResultRingBuffer.setRelease(ringBufferSlot, result);
+        resultAvailableInRingBufferSemaphores[ringBufferSlot].release();
     }
 
     /**
@@ -114,28 +180,45 @@ final class OrderByMoveIndexBlockingQueue<Solution_> {
     public MoveResult<Solution_> take() throws InterruptedException {
         int moveIndex = nextMoveIndex;
         nextMoveIndex++;
-        if (!backlog.isEmpty()) {
-            MoveResult<Solution_> result = backlog.remove(moveIndex);
-            if (result != null) {
-                return result;
-            }
+        int ringBufferIndex = moveIndex % moveResultRingBuffer.length();
+        resultAvailableInRingBufferSemaphores[ringBufferIndex].acquire();
+        MoveResult<Solution_> result = moveResultRingBuffer.getAcquire(ringBufferIndex);
+        moveResultRingBuffer.setRelease(ringBufferIndex, null);
+        spaceAvailableInRingBufferSemaphores[ringBufferIndex].release();
+        // If 2 exceptions are added from different threads concurrently, either one could end up first.
+        // This is a known deviation from 100% reproducibility, that never occurs in a success scenario.
+        if (result.hasThrownException()) {
+            throw new IllegalStateException("The move thread with moveThreadIndex ("
+                    + result.getMoveThreadIndex() + ") has thrown an exception."
+                    + " Relayed here in the parent thread.",
+                    result.getThrowable());
         }
-        while (true) {
-            MoveResult<Solution_> result = innerQueue.take();
-            // If 2 exceptions are added from different threads concurrently, either one could end up first.
-            // This is a known deviation from 100% reproducibility, that never occurs in a success scenario.
-            if (result.hasThrownException()) {
-                throw new IllegalStateException("The move thread with moveThreadIndex ("
-                        + result.getMoveThreadIndex() + ") has thrown an exception."
-                        + " Relayed here in the parent thread.",
-                        result.getThrowable());
-            }
-            if (result.getMoveIndex() == moveIndex) {
-                return result;
-            } else {
-                backlog.put(result.getMoveIndex(), result);
-            }
+        return result;
+    }
+
+    public void waitForDecider() {
+        try {
+            syncDeciderAndMoveThreadsStartBarrier.await();
+        } catch (InterruptedException | BrokenBarrierException e) {
+            throw new RuntimeException(e);
         }
+    }
+
+    public void blockMoveThreads() {
+        syncDeciderAndMoveThreads.setRelease(true);
+    }
+
+    public void deciderSyncOnEnd() {
+        try {
+            syncDeciderAndMoveThreadsEndBarrier.await();
+        } catch (InterruptedException | BrokenBarrierException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    public boolean checkIfBlocking() {
+        return syncDeciderAndMoveThreads.getAcquire();
     }
 
     public static class MoveResult<Solution_> {
@@ -200,7 +283,6 @@ final class OrderByMoveIndexBlockingQueue<Solution_> {
         private Throwable getThrowable() {
             return throwable;
         }
-
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/SharedNeverEndingMoveGenerator.java
+++ b/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/SharedNeverEndingMoveGenerator.java
@@ -1,0 +1,39 @@
+package ai.timefold.solver.enterprise.core.multithreaded;
+
+import ai.timefold.solver.core.impl.heuristic.move.Move;
+import ai.timefold.solver.core.impl.heuristic.move.NoChangeMove;
+
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicLong;
+
+public final class SharedNeverEndingMoveGenerator<Solution_> implements NeverEndingMoveGenerator<Solution_> {
+    final AtomicLong hasNextRemaining;
+    final Iterator<Move<Solution_>> delegateIterator;
+    final OrderByMoveIndexBlockingQueue<Solution_> resultQueue;
+    final static NoChangeMove<?> NO_CHANGE_MOVE = new NoChangeMove<>();
+    boolean hasNext = true;
+
+    SharedNeverEndingMoveGenerator(AtomicLong hasNextRemaining,
+                                       OrderByMoveIndexBlockingQueue<Solution_> resultQueue,
+                                       Iterator<Move<Solution_>> delegateIterator) {
+        this.hasNextRemaining = hasNextRemaining;
+        this.resultQueue = resultQueue;
+        this.delegateIterator = delegateIterator;
+    }
+
+    @SuppressWarnings("unchecked")
+    synchronized public Move<Solution_> generateNextMove() {
+        if (!hasNext) {
+            return (NoChangeMove<Solution_>) NO_CHANGE_MOVE;
+        }
+        if (delegateIterator.hasNext()) {
+            return delegateIterator.next();
+        } else {
+            hasNext = false;
+            if (hasNextRemaining.decrementAndGet() == 0) {
+                resultQueue.blockMoveThreads();
+            }
+            return (NoChangeMove<Solution_>) NO_CHANGE_MOVE;
+        }
+    }
+}

--- a/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/SharedNeverEndingMoveGenerator.java
+++ b/core/src/main/java/ai/timefold/solver/enterprise/core/multithreaded/SharedNeverEndingMoveGenerator.java
@@ -1,28 +1,41 @@
 package ai.timefold.solver.enterprise.core.multithreaded;
 
+import java.util.Iterator;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
 import ai.timefold.solver.core.impl.heuristic.move.Move;
 import ai.timefold.solver.core.impl.heuristic.move.NoChangeMove;
 
-import java.util.Iterator;
-import java.util.concurrent.atomic.AtomicLong;
-
 public final class SharedNeverEndingMoveGenerator<Solution_> implements NeverEndingMoveGenerator<Solution_> {
     final AtomicLong hasNextRemaining;
+    final AtomicInteger nextMoveIndex;
     final Iterator<Move<Solution_>> delegateIterator;
     final OrderByMoveIndexBlockingQueue<Solution_> resultQueue;
+    final Semaphore waitForDeciderSemaphore;
     final static NoChangeMove<?> NO_CHANGE_MOVE = new NoChangeMove<>();
     boolean hasNext = true;
 
     SharedNeverEndingMoveGenerator(AtomicLong hasNextRemaining,
-                                       OrderByMoveIndexBlockingQueue<Solution_> resultQueue,
-                                       Iterator<Move<Solution_>> delegateIterator) {
+            OrderByMoveIndexBlockingQueue<Solution_> resultQueue,
+            Iterator<Move<Solution_>> delegateIterator,
+            Semaphore waitForDeciderSemaphore) {
         this.hasNextRemaining = hasNextRemaining;
         this.resultQueue = resultQueue;
         this.delegateIterator = delegateIterator;
+        this.waitForDeciderSemaphore = waitForDeciderSemaphore;
+        this.nextMoveIndex = new AtomicInteger(0);
     }
 
     @SuppressWarnings("unchecked")
-    synchronized public Move<Solution_> generateNextMove() {
+    public Move<Solution_> generateNextMove() {
+        try {
+            waitForDeciderSemaphore.acquire();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
         if (!hasNext) {
             return (NoChangeMove<Solution_>) NO_CHANGE_MOVE;
         }
@@ -35,5 +48,10 @@ public final class SharedNeverEndingMoveGenerator<Solution_> implements NeverEnd
             }
             return (NoChangeMove<Solution_>) NO_CHANGE_MOVE;
         }
+    }
+
+    @Override
+    public int getNextMoveIndex() {
+        return nextMoveIndex.getAndIncrement();
     }
 }

--- a/core/src/test/java/ai/timefold/solver/enterprise/core/multithreaded/MultiThreadedSolverTest.java
+++ b/core/src/test/java/ai/timefold/solver/enterprise/core/multithreaded/MultiThreadedSolverTest.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.enterprise.core.multithreaded;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import ai.timefold.solver.core.api.solver.Solver;
@@ -11,6 +13,8 @@ import ai.timefold.solver.core.impl.heuristic.move.Move;
 import ai.timefold.solver.core.impl.heuristic.selector.move.factory.MoveListFactory;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
+import ai.timefold.solver.core.impl.testdata.domain.list.TestdataListEntity;
+import ai.timefold.solver.core.impl.testdata.domain.list.TestdataListSolution;
 import ai.timefold.solver.core.impl.testdata.util.PlannerAssert;
 import ai.timefold.solver.core.impl.testdata.util.PlannerTestUtils;
 
@@ -43,6 +47,18 @@ class MultiThreadedSolverTest {
 
         TestdataSolution solution = solver.solve(TestdataSolution.generateSolution());
         PlannerAssert.assertSolutionInitialized(solution);
+    }
+
+    @Test
+    void multiThreadedSolvingListVariable() {
+        SolverConfig solverConfig = PlannerTestUtils.buildSolverConfig(TestdataListSolution.class, TestdataListEntity.class);
+        solverConfig.setMoveThreadCount("1"); // Enable the multi-threaded solving.
+
+        SolverFactory<TestdataListSolution> solverFactory = SolverFactory.create(solverConfig);
+        Solver<TestdataListSolution> solver = solverFactory.buildSolver();
+
+        TestdataListSolution solution = solver.solve(TestdataListSolution.generateUninitializedSolution(10, 10));
+        assertThat(solution.getScore().initScore()).isEqualTo(0);
     }
 
     public static class TestMoveListFactory implements MoveListFactory<TestdataSolution> {

--- a/core/src/test/java/ai/timefold/solver/enterprise/core/multithreaded/OrderByMoveIndexBlockingQueueTest.java
+++ b/core/src/test/java/ai/timefold/solver/enterprise/core/multithreaded/OrderByMoveIndexBlockingQueueTest.java
@@ -4,12 +4,7 @@ import static ai.timefold.solver.core.impl.testdata.util.PlannerAssert.assertCod
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.impl.heuristic.move.DummyMove;
@@ -155,7 +150,7 @@ class OrderByMoveIndexBlockingQueueTest {
         });
         allPrecedingTasksFinished.await();
         IllegalArgumentException exception = new IllegalArgumentException();
-        Future<?> exceptionFuture = executorService.submit(() -> queue.addExceptionThrown(3, exception));
+        Future<?> exceptionFuture = executorService.submit(() -> queue.addExceptionThrown(1, 3, exception));
         exceptionFuture.get(); // Avoid random failing test when the task hasn't started yet or the next task finishes earlier
         executorService.submit(() -> queue.addMove(0, 1, 2, new DummyMove("b2"), SimpleScore.of(-2))).get();
         assertResult("b0", false, queue.take());
@@ -179,7 +174,7 @@ class OrderByMoveIndexBlockingQueueTest {
         executorService.submit(() -> queue.addMove(0, 0, 2, new DummyMove("a2"), SimpleScore.of(-2)));
         executorService.submit(() -> queue.addMove(1, 0, 3, new DummyMove("a3"), SimpleScore.of(-3)));
         IllegalArgumentException exception = new IllegalArgumentException();
-        Future<?> exceptionFuture = executorService.submit(() -> queue.addExceptionThrown(1, exception));
+        Future<?> exceptionFuture = executorService.submit(() -> queue.addExceptionThrown(0, 1, exception));
         assertThatThrownBy(() -> {
             assertResult("a0", 0, queue.take());
             assertResult("a1", -1, queue.take());

--- a/core/src/test/java/ai/timefold/solver/enterprise/core/multithreaded/SolverConfigMultiThreadedTest.java
+++ b/core/src/test/java/ai/timefold/solver/enterprise/core/multithreaded/SolverConfigMultiThreadedTest.java
@@ -25,7 +25,6 @@ class SolverConfigMultiThreadedTest {
         runSolvingAndVerifySolution(10, 20, "256");
     }
 
-    @Disabled("PLANNER-1180")
     @Test
     @Timeout(5)
     void solvingOfVerySmallProblemFinishes() {

--- a/core/src/test/java/ai/timefold/solver/enterprise/core/multithreaded/SolverConfigMultiThreadedTest.java
+++ b/core/src/test/java/ai/timefold/solver/enterprise/core/multithreaded/SolverConfigMultiThreadedTest.java
@@ -13,7 +13,6 @@ import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
 import ai.timefold.solver.core.impl.testdata.util.PlannerTestUtils;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 

--- a/core/src/test/java/ai/timefold/solver/enterprise/core/multithreaded/SolverConfigMultiThreadedTest.java
+++ b/core/src/test/java/ai/timefold/solver/enterprise/core/multithreaded/SolverConfigMultiThreadedTest.java
@@ -13,6 +13,7 @@ import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataValue;
 import ai.timefold.solver.core.impl.testdata.util.PlannerTestUtils;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -24,6 +25,7 @@ class SolverConfigMultiThreadedTest {
         runSolvingAndVerifySolution(10, 20, "256");
     }
 
+    @Disabled("PLANNER-1180")
     @Test
     @Timeout(5)
     void solvingOfVerySmallProblemFinishes() {


### PR DESCRIPTION
This is a work-in-progress.

It attempts to make multi-threaded solving scale more linearly by allowing each MoveThreadRunner to generate it own moves (and thus spend less time being blocked by the decider).

Instead of MultiThreadedConstructionHeuristicDecider and
MultiThreadedLocalSearchDecider filling up the operationQueue
with MoveEvaluationOperation, each MoveThreadRunner will generate
it own move instead. This allows every MoveThreadRunner to evaluate
moves without waiting on the Decider. As a result, the operationQueue
will only contain ApplyStepOperation, DestroyOperation and
SetupOperation.

The MoveThreadRunner threads now will only block when:

- Waiting for the Decider to setup the step (new)
- Waiting for all MoveThreadRunner to apply a step
- Waiting for space in the result buffer
- When the iterator is exhausted

Currently, the MoveThreadRunner share the same iterator, but the code
is structured in a way so it can easily be adapted so each
MoveThreadRunner has it own independent iterator.

OrderByMoveIndexBlockingQueue becomes the main syncing method between
the MoveThreadRunners and the Decider:

- It blocks the decider on startNextStep until all MoveThreadRunners are
  ready
- It blocks the MoveThreadRunners when all iterators are exhausted or
  when the Decider has finished a step (whichever comes first)
- It also block the MoveThreadRunner when the slot it is writing to
  has not been read by the Decider (and the Decider is correspondingly
  also blocked until a MoveThreadRunner put a result into that slot).

It employs two cyclic barriers (for moveThreadCount + 1 parties). First,
a start barrier, to prevent the move threads from corrupting the internals
that need to be fully setup before they put in new results. Second, a
end barrier, to prevent the move threads from infinitely populating
the buffer with no-op evaluations when all the iterators are exhausted.

The MoveThreadRunner generate their moves by sharing an AtomicInteger
that tracks the current move index. They atomically get and increment
that integer, and use it to select an iterator from an
AtomicReferenceArray. Move index 0 always get iterator 0, move index 1
always get iterator 1, and so on. In general, the move with index x is
generated from the iterator at index x mod moveThreadCount.
There are exactly moveThreadCount iterators, so each move thread can
concurrently generate their own moves without blocking if they use
independent iterators. In the case they use a shared iterator (i.e.
the one currently implemented), they'll only use it one at a time.
The MoveThreadRunner takes operations from the operationQueue if it is
not empty; otherwise it will create it own MoveEvaluationOperation.

MoveThreadRunner synchronize on the move iterator so that it does not get corrupted by two threads using it at the same time (if one thread was particularly
fast at evaluating its move). They also wait for decider catchup using a
semaphore, which also tells the decider how many additional moves it
need to generate to guarantee reproducibility. They use the NeverEndingMoveGenerator to get the actual move index, since the first to enter the synchronized block may not be the first thread that reached it.