### PR TITLE
perf: Share lambdas in ConstraintProvider in Quarkus

### DIFF
--- a/asm/pom.xml
+++ b/asm/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>ai.timefold.solver.enterprise</groupId>
+    <artifactId>timefold-solver-enterprise-build-parent</artifactId>
+    <version>999-SNAPSHOT</version>
+    <relativePath>../build/build-parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>timefold-solver-enterprise-asm</artifactId>
+
+  <name>Timefold Solver Enterprise Edition ASM</name>
+  <description>
+    Timefold solves planning problems.
+    This lightweight, embeddable planning engine implements powerful and scalable algorithms
+    to optimize business resource scheduling and planning.
+
+    This module contains the commercial features of Timefold Solver Enterprise Edition that requires ASM.
+  </description>
+  <url>https://timefold.ai</url>
+
+  <packaging>jar</packaging>
+
+  <properties>
+    <java.module.name>ai.timefold.solver.enterprise.asm</java.module.name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>ai.timefold.solver</groupId>
+      <artifactId>timefold-solver-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.timefold.solver</groupId>
+      <artifactId>timefold-solver-core-impl</artifactId>
+    </dependency>
+
+    <!-- ASM dependencies -->
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-util</artifactId>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>ai.timefold.solver</groupId>
+      <artifactId>timefold-solver-core-impl</artifactId>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <dependency>ai.timefold.solver:timefold-solver-core:jar</dependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/asm/src/main/java/ai/timefold/solver/enterprise/asm/lambda/BytecodeRecordingClassVisitor.java
+++ b/asm/src/main/java/ai/timefold/solver/enterprise/asm/lambda/BytecodeRecordingClassVisitor.java
@@ -1,0 +1,50 @@
+package ai.timefold.solver.enterprise.asm.lambda;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+final class BytecodeRecordingClassVisitor extends ClassVisitor {
+    private final Map<String, String> methodNameToBytecode = new HashMap<>();
+    private final Map<String, String> methodIdToCanonicalMethodId;
+
+    BytecodeRecordingClassVisitor(ClassVisitor classVisitor, Map<String, String> methodIdToCanonicalMethodId) {
+        super(Opcodes.ASM9, classVisitor);
+        this.methodIdToCanonicalMethodId = methodIdToCanonicalMethodId;
+    }
+
+    @Override
+    public MethodVisitor visitMethod(
+            final int access,
+            final String name,
+            final String descriptor,
+            final String signature,
+            final String[] exceptions) {
+        return new BytecodeRecordingMethodVisitor(super.visitMethod(access, name, descriptor, signature, exceptions),
+                (bytecode) -> {
+                    String key = LambdaSharingMethodVisitor.getMethodId(name, descriptor);
+                    for (Map.Entry<String, String> existingBytecodeEntry : methodNameToBytecode.entrySet()) {
+                        String existingKey = existingBytecodeEntry.getKey();
+                        String existingMethodDescriptor = LambdaSharingMethodVisitor.getDescriptor(existingKey);
+                        if (!descriptor.equals(existingMethodDescriptor)) {
+                            continue;
+                        }
+                        String existingBytecode = existingBytecodeEntry.getValue();
+                        if (existingBytecode.equals(bytecode)) {
+                            methodIdToCanonicalMethodId.put(key, existingKey);
+                            return;
+                        }
+                    }
+                    methodNameToBytecode.put(key, bytecode);
+                    methodIdToCanonicalMethodId.put(key, key);
+                });
+    }
+
+    @Override
+    public void visitEnd() {
+        super.visitEnd();
+    }
+}

--- a/asm/src/main/java/ai/timefold/solver/enterprise/asm/lambda/BytecodeRecordingMethodVisitor.java
+++ b/asm/src/main/java/ai/timefold/solver/enterprise/asm/lambda/BytecodeRecordingMethodVisitor.java
@@ -1,0 +1,47 @@
+package ai.timefold.solver.enterprise.asm.lambda;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.function.Consumer;
+
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.commons.InstructionAdapter;
+import org.objectweb.asm.util.Printer;
+import org.objectweb.asm.util.Textifier;
+import org.objectweb.asm.util.TraceMethodVisitor;
+
+final class BytecodeRecordingMethodVisitor extends InstructionAdapter {
+    public BytecodeRecordingMethodVisitor(MethodVisitor methodVisitor, Consumer<String> methodBytecodeConsumer) {
+        super(Opcodes.ASM9, getBytecodeRecorder(methodVisitor, methodBytecodeConsumer));
+    }
+
+    private static MethodVisitor getBytecodeRecorder(final MethodVisitor methodVisitor,
+            Consumer<String> methodBytecodeConsumer) {
+        Printer p = new Textifier(Opcodes.ASM9) {
+            @Override
+            public void visitLineNumber(int number, Label label) {
+                // Record nothing; metadata
+            }
+
+            @Override
+            public void visitLocalVariable(final String name,
+                    final String descriptor,
+                    final String signature,
+                    final Label start,
+                    final Label end,
+                    final int index) {
+                // Record nothing; metadata
+            }
+
+            @Override
+            public void visitMethodEnd() {
+                StringWriter out = new StringWriter();
+                print(new PrintWriter(out));
+                methodBytecodeConsumer.accept(out.toString());
+            }
+        };
+        return new TraceMethodVisitor(methodVisitor, p);
+    }
+}

--- a/asm/src/main/java/ai/timefold/solver/enterprise/asm/lambda/LambdaSharingClassVisitor.java
+++ b/asm/src/main/java/ai/timefold/solver/enterprise/asm/lambda/LambdaSharingClassVisitor.java
@@ -1,0 +1,38 @@
+package ai.timefold.solver.enterprise.asm.lambda;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+final class LambdaSharingClassVisitor extends ClassVisitor {
+    private final Map<String, String> methodIdToCanonicalMethodId;
+    private final String classInternalName;
+    private final Map<String, LambdaSharingMethodVisitor.InvokeDynamicArgs> generatedFieldNameToInvokeDynamicArgs;
+    private final Map<LambdaSharingMethodVisitor.MethodReferenceId, String> methodReferenceIdToGeneratedFieldName =
+            new HashMap<>();
+    private final Map<LambdaSharingMethodVisitor.LambdaId, String> lambdaIdToGeneratedFieldName = new HashMap<>();
+
+    LambdaSharingClassVisitor(ClassVisitor classVisitor, String className,
+            Map<String, String> methodIdToCanonicalMethodId,
+            Map<String, LambdaSharingMethodVisitor.InvokeDynamicArgs> generatedFieldNameToInvokeDynamicArgs) {
+        super(Opcodes.ASM9, classVisitor);
+        this.methodIdToCanonicalMethodId = methodIdToCanonicalMethodId;
+        this.generatedFieldNameToInvokeDynamicArgs = generatedFieldNameToInvokeDynamicArgs;
+        this.classInternalName = className.replace('.', '/');
+    }
+
+    @Override
+    public MethodVisitor visitMethod(
+            final int access,
+            final String name,
+            final String descriptor,
+            final String signature,
+            final String[] exceptions) {
+        return new LambdaSharingMethodVisitor(super.visitMethod(access, name, descriptor, signature, exceptions),
+                classInternalName, methodIdToCanonicalMethodId, methodReferenceIdToGeneratedFieldName,
+                lambdaIdToGeneratedFieldName, generatedFieldNameToInvokeDynamicArgs);
+    }
+}

--- a/asm/src/main/java/ai/timefold/solver/enterprise/asm/lambda/LambdaSharingEnhancer.java
+++ b/asm/src/main/java/ai/timefold/solver/enterprise/asm/lambda/LambdaSharingEnhancer.java
@@ -1,0 +1,55 @@
+package ai.timefold.solver.enterprise.asm.lambda;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+
+public class LambdaSharingEnhancer {
+    public static byte[] shareLambdasInClass(Class<?> clazz) throws IOException {
+        try (InputStream bytecodeInputStream = ClassLoader.getSystemResourceAsStream(
+                clazz.getName().replace('.', '/') + ".class")) {
+            if (bytecodeInputStream == null) {
+                throw new IllegalArgumentException("Could not locate bytecode for class (" + clazz + ").");
+            }
+            return shareLambdasInBytecode(clazz.getName(), bytecodeInputStream.readAllBytes());
+        }
+    }
+
+    public static byte[] shareLambdasInBytecode(String name, byte[] inputBytes) {
+        Map<String, String> methodNameToCanonicalMethod = new HashMap<>();
+        Map<String, LambdaSharingMethodVisitor.InvokeDynamicArgs> generatedFieldNameToInvokeDynamicArgs = new LinkedHashMap<>();
+
+        // First pass: record method bytecode
+        ClassWriter classWriter = new ClassWriter(Opcodes.ASM9);
+        ClassVisitor classVisitor =
+                new BytecodeRecordingClassVisitor(classWriter, methodNameToCanonicalMethod);
+        ClassReader classReader = new ClassReader(inputBytes);
+        classReader.accept(classVisitor, Opcodes.ASM9);
+
+        // Second pass: replace lambdas with static field reads
+        inputBytes = classWriter.toByteArray();
+        classWriter = new ClassWriter(Opcodes.ASM9);
+        classVisitor =
+                new LambdaSharingClassVisitor(classWriter, name, methodNameToCanonicalMethod,
+                        generatedFieldNameToInvokeDynamicArgs);
+        classReader = new ClassReader(inputBytes);
+        classReader.accept(classVisitor, Opcodes.ASM9);
+        inputBytes = classWriter.toByteArray();
+
+        // Final pass: initialize static fields with recorded invokedynamic
+        classWriter = new ClassWriter(Opcodes.ASM9);
+        classVisitor =
+                new SharedLambdaFieldsInitializerClassVisitor(classWriter, name,
+                        generatedFieldNameToInvokeDynamicArgs);
+        classReader = new ClassReader(inputBytes);
+        classReader.accept(classVisitor, Opcodes.ASM9);
+        return classWriter.toByteArray();
+    }
+}

--- a/asm/src/main/java/ai/timefold/solver/enterprise/asm/lambda/LambdaSharingMethodVisitor.java
+++ b/asm/src/main/java/ai/timefold/solver/enterprise/asm/lambda/LambdaSharingMethodVisitor.java
@@ -1,0 +1,229 @@
+package ai.timefold.solver.enterprise.asm.lambda;
+
+import java.lang.invoke.*;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.*;
+
+import ai.timefold.solver.core.api.function.*;
+
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+/**
+ * This {@link MethodVisitor} creates temporarily invalid bytecode; It converts lambdas/method references to fields reads, but
+ * does not create/initialize fields. The reason is we need to initialize the fields in clinit, but clinit itself need to be
+ * visited, and we do not know the fields or their initializers until visitEnd of this visitor is called.
+ */
+final class LambdaSharingMethodVisitor extends InstructionAdapter {
+    public record FunctionInterfaceId(String classDescriptor, Type methodGenericType) {
+    }
+
+    public record MethodReferenceId(FunctionInterfaceId functionInterfaceId, Handle methodHandle) {
+    }
+
+    public record LambdaId(FunctionInterfaceId functionInterfaceId, String methodId) {
+    }
+
+    public record InvokeDynamicArgs(String name, String descriptor, Handle bootstrapMethodHandle,
+            Object[] bootstrapMethodArguments, String signature) {
+        public Type getFieldDescriptor() {
+            return Type.getReturnType(descriptor);
+        }
+    }
+
+    final Map<String, String> methodIdToCanonicalMethodId;
+    final Map<MethodReferenceId, String> methodReferenceIdToGeneratedFieldName;
+    final Map<LambdaId, String> lambdaIdToGeneratedFieldName;
+    final Map<String, InvokeDynamicArgs> generatedFieldNameToInvokeDynamicArgs;
+    final String classInternalName;
+
+    public LambdaSharingMethodVisitor(MethodVisitor methodVisitor, String classInternalName,
+            Map<String, String> methodIdToCanonicalMethodId,
+            Map<MethodReferenceId, String> methodReferenceIdToGeneratedFieldName,
+            Map<LambdaId, String> lambdaIdToGeneratedFieldName,
+            Map<String, InvokeDynamicArgs> generatedFieldNameToInvokeDynamicArgs) {
+        super(Opcodes.ASM9, methodVisitor);
+        this.classInternalName = classInternalName;
+        this.methodIdToCanonicalMethodId = methodIdToCanonicalMethodId;
+        this.methodReferenceIdToGeneratedFieldName = methodReferenceIdToGeneratedFieldName;
+        this.lambdaIdToGeneratedFieldName = lambdaIdToGeneratedFieldName;
+        this.generatedFieldNameToInvokeDynamicArgs = generatedFieldNameToInvokeDynamicArgs;
+    }
+
+    static String getMethodId(String name, String descriptor) {
+        return name + " " + descriptor;
+    }
+
+    static String getMethodName(String key) {
+        return key.substring(0, key.indexOf(' '));
+    }
+
+    static String getDescriptor(String key) {
+        return key.substring(key.indexOf(' ') + 1);
+    }
+
+    @Override
+    public void invokedynamic(
+            final String name,
+            final String descriptor,
+            final Handle bootstrapMethodHandle,
+            final Object[] bootstrapMethodArguments) {
+        if (Type.getMethodType(descriptor).getArgumentTypes().length != 0) {
+            // The lambda depends on variables used in the method and thus cannot be transformed
+            super.invokedynamic(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments);
+            return;
+        }
+        if (!bootstrapMethodHandle.getOwner().equals(Type.getInternalName(LambdaMetafactory.class))) {
+            super.invokedynamic(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments);
+            return;
+        }
+        if (!bootstrapMethodHandle.getName().equals("metafactory")) {
+            super.invokedynamic(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments);
+            return;
+        }
+        if (!bootstrapMethodHandle.getDesc().equals(Type.getMethodDescriptor(
+                Type.getType(CallSite.class),
+                Type.getType(MethodHandles.Lookup.class),
+                Type.getType(String.class),
+                Type.getType(MethodType.class),
+                Type.getType(MethodType.class),
+                Type.getType(MethodHandle.class),
+                Type.getType(MethodType.class)))) {
+            super.invokedynamic(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments);
+            return;
+        }
+        if (bootstrapMethodArguments.length != 3) {
+            super.invokedynamic(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments);
+            return;
+        }
+        Handle methodHandle = (Handle) bootstrapMethodArguments[1];
+        Type methodGenericSignature = (Type) bootstrapMethodArguments[2];
+
+        if (!methodHandle.getOwner().equals(classInternalName)) {
+            replaceMethodReference(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments, methodHandle,
+                    methodGenericSignature);
+        } else {
+            replaceLambda(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments, methodHandle,
+                    methodGenericSignature);
+        }
+    }
+
+    private void replaceMethodReference(final String name,
+            final String descriptor,
+            final Handle bootstrapMethodHandle,
+            final Object[] bootstrapMethodArguments,
+            Handle methodHandle,
+            Type methodGenericSignature) {
+        MethodReferenceId methodReferenceId =
+                new MethodReferenceId(new FunctionInterfaceId(descriptor, methodGenericSignature), methodHandle);
+        replaceDynamicWithFieldRead(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments,
+                methodGenericSignature, methodReferenceIdToGeneratedFieldName, methodReferenceId);
+    }
+
+    private void replaceLambda(final String name,
+            final String descriptor,
+            final Handle bootstrapMethodHandle,
+            final Object[] bootstrapMethodArguments,
+            Handle methodHandle,
+            Type methodGenericSignature) {
+        String methodKey = getMethodId(methodHandle.getName(), methodHandle.getDesc());
+        String canonicalMethodId = methodIdToCanonicalMethodId.get(methodKey);
+        LambdaId lambdaId = new LambdaId(new FunctionInterfaceId(descriptor, methodGenericSignature), canonicalMethodId);
+        replaceDynamicWithFieldRead(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments,
+                methodGenericSignature, lambdaIdToGeneratedFieldName, lambdaId);
+    }
+
+    private <Key_> void replaceDynamicWithFieldRead(final String name,
+            final String descriptor,
+            final Handle bootstrapMethodHandle,
+            final Object[] bootstrapMethodArguments,
+            Type methodGenericSignature,
+            Map<Key_, String> idToGeneratedField,
+            Key_ id) {
+        Type fieldType = Type.getReturnType(descriptor);
+        if (idToGeneratedField.containsKey(id)) {
+            String generatedFieldName = idToGeneratedField.get(id);
+            this.getstatic(classInternalName, generatedFieldName, fieldType.getDescriptor());
+            return;
+        }
+        int fieldId = generatedFieldNameToInvokeDynamicArgs.size();
+        String generatedFieldName = "$timefoldSharedLambda" + fieldId;
+        String signature = FunctionalInterface.getInterfaceSignature(Type.getReturnType(descriptor), methodGenericSignature);
+        generatedFieldNameToInvokeDynamicArgs.put(generatedFieldName,
+                new InvokeDynamicArgs(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments, signature));
+        idToGeneratedField.put(id, generatedFieldName);
+        this.getstatic(classInternalName, generatedFieldName, fieldType.getDescriptor());
+    }
+
+    private enum FunctionalInterface {
+        // Predicates
+        PREDICATE(Predicate.class, Type::getArgumentTypes),
+        BI_PREDICATE(BiPredicate.class, Type::getArgumentTypes),
+        TRI_PREDICATE(TriPredicate.class, Type::getArgumentTypes),
+        QUAD_PREDICATE(QuadPredicate.class, Type::getArgumentTypes),
+        PENTA_PREDICATE(PentaPredicate.class, Type::getArgumentTypes),
+
+        // Functions
+        FUNCTION(Function.class, sig -> append(sig.getArgumentTypes(), sig.getReturnType())),
+        BI_FUNCTION(BiFunction.class, sig -> append(sig.getArgumentTypes(), sig.getReturnType())),
+        TRI_FUNCTION(TriFunction.class, sig -> append(sig.getArgumentTypes(), sig.getReturnType())),
+        QUAD_FUNCTION(QuadFunction.class, sig -> append(sig.getArgumentTypes(), sig.getReturnType())),
+        PENTA_FUNCTION(PentaFunction.class, sig -> append(sig.getArgumentTypes(), sig.getReturnType())),
+
+        // ToIntFunctions
+        TO_INT_FUNCTION(ToIntFunction.class, Type::getArgumentTypes),
+        TO_INT_BI_FUNCTION(ToIntBiFunction.class, Type::getArgumentTypes),
+        TO_INT_TRI_FUNCTION(ToIntTriFunction.class, Type::getArgumentTypes),
+        TO_INT_QUAD_FUNCTION(ToIntQuadFunction.class, Type::getArgumentTypes),
+
+        // ToLongFunctions
+        TO_LONG_FUNCTION(ToIntFunction.class, Type::getArgumentTypes),
+        TO_LONG_BI_FUNCTION(ToIntBiFunction.class, Type::getArgumentTypes),
+        TO_LONG_TRI_FUNCTION(ToIntTriFunction.class, Type::getArgumentTypes),
+        TO_LONG_QUAD_FUNCTION(ToIntQuadFunction.class, Type::getArgumentTypes);
+
+        final Class<?> interfaceClass;
+        final Function<Type, Type[]> methodGenericSignatureToClassGenericArgs;
+
+        FunctionalInterface(Class<?> interfaceClass,
+                Function<Type, Type[]> methodGenericSignatureToClassGenericArgs) {
+            this.interfaceClass = interfaceClass;
+            this.methodGenericSignatureToClassGenericArgs = methodGenericSignatureToClassGenericArgs;
+        }
+
+        private static Type[] append(Type[] elements, Type appended) {
+            Type[] out = Arrays.copyOf(elements, elements.length + 1);
+            out[elements.length] = appended;
+            return out;
+        }
+
+        public String getInterfaceSignature(Type methodGenericSignature) {
+            Type[] genericArguments = methodGenericSignatureToClassGenericArgs.apply(methodGenericSignature);
+            StringBuilder out = new StringBuilder();
+
+            out.append("L");
+            out.append(Type.getInternalName(interfaceClass));
+            out.append("<");
+
+            for (Type genericArgument : genericArguments) {
+                out.append(genericArgument.getDescriptor());
+            }
+
+            out.append(">;");
+            return out.toString();
+        }
+
+        public static String getInterfaceSignature(Type interfaceType, Type methodGenericSignature) {
+            for (FunctionalInterface functionalInterface : values()) {
+                if (Type.getType(functionalInterface.interfaceClass).equals(interfaceType)) {
+                    return functionalInterface.getInterfaceSignature(methodGenericSignature);
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/asm/src/main/java/ai/timefold/solver/enterprise/asm/lambda/SharedLambdaFieldsInitializerClassVisitor.java
+++ b/asm/src/main/java/ai/timefold/solver/enterprise/asm/lambda/SharedLambdaFieldsInitializerClassVisitor.java
@@ -1,0 +1,62 @@
+package ai.timefold.solver.enterprise.asm.lambda;
+
+import java.lang.reflect.Modifier;
+import java.util.Map;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+final class SharedLambdaFieldsInitializerClassVisitor extends ClassVisitor {
+    private final String classInternalName;
+    private final Map<String, LambdaSharingMethodVisitor.InvokeDynamicArgs> generatedFieldNameToInvokeDynamicArgs;
+    private boolean hasClinit = false;
+
+    SharedLambdaFieldsInitializerClassVisitor(ClassVisitor classVisitor, String className,
+            Map<String, LambdaSharingMethodVisitor.InvokeDynamicArgs> generatedFieldNameToInvokeDynamicArgs) {
+        super(Opcodes.ASM9, classVisitor);
+        this.generatedFieldNameToInvokeDynamicArgs = generatedFieldNameToInvokeDynamicArgs;
+        this.classInternalName = className.replace('.', '/');
+
+        for (Map.Entry<String, LambdaSharingMethodVisitor.InvokeDynamicArgs> generatedFieldAndInitializerEntry : generatedFieldNameToInvokeDynamicArgs
+                .entrySet()) {
+            String fieldName = generatedFieldAndInitializerEntry.getKey();
+            var invokeDynamicArgs = generatedFieldAndInitializerEntry.getValue();
+            Type fieldDescriptor = invokeDynamicArgs.getFieldDescriptor();
+            classVisitor.visitField(Modifier.FINAL | Modifier.PRIVATE | Modifier.STATIC,
+                    fieldName, fieldDescriptor.getDescriptor(), invokeDynamicArgs.signature(), null);
+        }
+    }
+
+    @Override
+    public MethodVisitor visitMethod(
+            final int access,
+            final String name,
+            final String descriptor,
+            final String signature,
+            final String[] exceptions) {
+        if (name.equals("<clinit>")) {
+            hasClinit = true;
+            return new SharedLambdaFieldsInitializerMethodVisitor(Opcodes.ASM9,
+                    super.visitMethod(access, name, descriptor, signature, exceptions),
+                    classInternalName, generatedFieldNameToInvokeDynamicArgs);
+
+        } else {
+            return super.visitMethod(access, name, descriptor, signature, exceptions);
+        }
+    }
+
+    @Override
+    public void visitEnd() {
+        if (!hasClinit) {
+            MethodVisitor methodVisitor = visitMethod(Modifier.PUBLIC | Modifier.STATIC, "<clinit>",
+                    Type.getMethodDescriptor(Type.VOID_TYPE), null, null);
+            methodVisitor.visitCode();
+            methodVisitor.visitMaxs(1, 0);
+            methodVisitor.visitInsn(Opcodes.RETURN);
+            methodVisitor.visitEnd();
+        }
+        super.visitEnd();
+    }
+}

--- a/asm/src/main/java/ai/timefold/solver/enterprise/asm/lambda/SharedLambdaFieldsInitializerMethodVisitor.java
+++ b/asm/src/main/java/ai/timefold/solver/enterprise/asm/lambda/SharedLambdaFieldsInitializerMethodVisitor.java
@@ -1,0 +1,41 @@
+package ai.timefold.solver.enterprise.asm.lambda;
+
+import java.util.Map;
+
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+final class SharedLambdaFieldsInitializerMethodVisitor extends MethodVisitor {
+    private final String internalClassName;
+    private final Map<String, LambdaSharingMethodVisitor.InvokeDynamicArgs> generatedFieldNameToInvokeDynamicArgs;
+
+    SharedLambdaFieldsInitializerMethodVisitor(int api, MethodVisitor methodVisitor,
+            String internalClassName,
+            Map<String, LambdaSharingMethodVisitor.InvokeDynamicArgs> generatedFieldNameToInvokeDynamicArgs) {
+        super(api, methodVisitor);
+        this.internalClassName = internalClassName;
+        this.generatedFieldNameToInvokeDynamicArgs = generatedFieldNameToInvokeDynamicArgs;
+    }
+
+    @Override
+    public void visitCode() {
+        for (Map.Entry<String, LambdaSharingMethodVisitor.InvokeDynamicArgs> generatedFieldNameAndInitializerEntry : generatedFieldNameToInvokeDynamicArgs
+                .entrySet()) {
+            String generatedFieldName = generatedFieldNameAndInitializerEntry.getKey();
+            LambdaSharingMethodVisitor.InvokeDynamicArgs invokeDynamicArgs = generatedFieldNameAndInitializerEntry.getValue();
+            mv.visitInvokeDynamicInsn(invokeDynamicArgs.name(),
+                    invokeDynamicArgs.descriptor(),
+                    invokeDynamicArgs.bootstrapMethodHandle(),
+                    invokeDynamicArgs.bootstrapMethodArguments());
+            mv.visitFieldInsn(Opcodes.PUTSTATIC, internalClassName, generatedFieldName,
+                    invokeDynamicArgs.getFieldDescriptor().getDescriptor());
+        }
+        super.visitCode();
+    }
+
+    @Override
+    public void visitMaxs(int maxStack, int maxLocals) {
+        // In case there a static block that only calls a static void method taking no parameters
+        super.visitMaxs(Math.max(1, maxStack), maxLocals);
+    }
+}

--- a/asm/src/test/java/ai/timefold/solver/enterprise/asm/lambda/LambdaSharingEnhancerTest.java
+++ b/asm/src/test/java/ai/timefold/solver/enterprise/asm/lambda/LambdaSharingEnhancerTest.java
@@ -1,0 +1,81 @@
+package ai.timefold.solver.enterprise.asm.lambda;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+public class LambdaSharingEnhancerTest {
+    private static class SharedLambdas {
+        Function<String, Integer> a1() {
+            return String::length;
+        }
+
+        Function<String, Integer> a2() {
+            return String::length;
+        }
+
+        Function<String, Integer> b1() {
+            return s -> s.length() + 1;
+        }
+
+        Function<String, Integer> b2() {
+            return s -> s.length() + 1;
+        }
+
+        BiFunction<String, String, Integer> biFunctionB() {
+            return (s, s2) -> s.length() + 1;
+        }
+
+        Function<String, Integer> c() {
+            return s -> s.length() + 2;
+        }
+
+        Function<String, Long> d() {
+            return s -> s.length() + 1L;
+        }
+
+        Supplier<Integer> supplier(int value) {
+            return () -> value;
+        }
+
+        Supplier<Boolean> predicate(String value) {
+            return value::isEmpty;
+        }
+    }
+
+    @Test
+    void sharesLambdas() throws Throwable {
+        MethodHandles.Lookup lookup = MethodHandles.lookup().defineHiddenClass(
+                LambdaSharingEnhancer.shareLambdasInClass(SharedLambdas.class), true);
+        Class<?> clazz = lookup.lookupClass();
+        Object instance = lookup.findConstructor(clazz, MethodType.methodType(void.class)).invoke();
+        assertThat(lookup.findVirtual(clazz, "a1", MethodType.methodType(Function.class)).invoke(instance))
+                .isSameAs(lookup.findVirtual(clazz, "a2", MethodType.methodType(Function.class)).invoke(instance));
+        assertThat(lookup.findVirtual(clazz, "b1", MethodType.methodType(Function.class)).invoke(instance))
+                .isSameAs(lookup.findVirtual(clazz, "b2", MethodType.methodType(Function.class)).invoke(instance));
+        assertThat(lookup.findVirtual(clazz, "a1", MethodType.methodType(Function.class)).invoke(instance))
+                .isNotSameAs(lookup.findVirtual(clazz, "b1", MethodType.methodType(Function.class)).invoke(instance));
+        assertThat(lookup.findVirtual(clazz, "b1", MethodType.methodType(Function.class)).invoke(instance))
+                .isNotSameAs(
+                        lookup.findVirtual(clazz, "biFunctionB", MethodType.methodType(BiFunction.class)).invoke(instance));
+        assertThat(lookup.findVirtual(clazz, "b1", MethodType.methodType(Function.class)).invoke(instance))
+                .isNotSameAs(lookup.findVirtual(clazz, "c", MethodType.methodType(Function.class)).invoke(instance));
+        assertThat(lookup.findVirtual(clazz, "b1", MethodType.methodType(Function.class)).invoke(instance))
+                .isNotSameAs(lookup.findVirtual(clazz, "d", MethodType.methodType(Function.class)).invoke(instance));
+        assertThat(lookup.findVirtual(clazz, "c", MethodType.methodType(Function.class)).invoke(instance))
+                .isNotSameAs(lookup.findVirtual(clazz, "d", MethodType.methodType(Function.class)).invoke(instance));
+        assertThat(lookup.findVirtual(clazz, "supplier", MethodType.methodType(Supplier.class, int.class)).invoke(instance, 0))
+                .isNotSameAs(lookup.findVirtual(clazz, "supplier", MethodType.methodType(Supplier.class, int.class))
+                        .invoke(instance, 0));
+        assertThat(lookup.findVirtual(clazz, "predicate", MethodType.methodType(Supplier.class, String.class)).invoke(instance,
+                "a"))
+                .isNotSameAs(lookup.findVirtual(clazz, "predicate", MethodType.methodType(Supplier.class, String.class))
+                        .invoke(instance, "a"));
+    }
+}

--- a/build/bom/pom.xml
+++ b/build/bom/pom.xml
@@ -57,6 +57,17 @@
       </dependency>
       <dependency>
         <groupId>ai.timefold.solver.enterprise</groupId>
+        <artifactId>timefold-solver-enterprise-asm</artifactId>
+        <version>${version.ai.timefold.solver}</version>
+      </dependency>
+      <dependency>
+        <groupId>ai.timefold.solver.enterprise</groupId>
+        <artifactId>timefold-solver-enterprise-asm</artifactId>
+        <version>${version.ai.timefold.solver}</version>
+        <type>sources</type>
+      </dependency>
+      <dependency>
+        <groupId>ai.timefold.solver.enterprise</groupId>
         <artifactId>timefold-solver-enterprise-quarkus</artifactId>
         <version>${version.ai.timefold.solver}</version>
       </dependency>

--- a/build/build-parent/pom.xml
+++ b/build/build-parent/pom.xml
@@ -18,6 +18,10 @@
 
   <properties>
     <!-- ************************************************************************ -->
+    <!-- Dependencies -->
+    <!-- ************************************************************************ -->
+    <version.io.quarkus>3.6.1</version.io.quarkus>
+    <!-- ************************************************************************ -->
     <!-- Plugins -->
     <!-- ************************************************************************ -->
     <version.compiler.plugin>3.11.0</version.compiler.plugin>
@@ -81,12 +85,24 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-bom</artifactId>
+        <version>${version.io.quarkus}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-maven-plugin</artifactId>
+          <version>${version.io.quarkus}</version>
+        </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
           <version>${version.dependency.plugin}</version>
@@ -449,7 +465,8 @@
     <profile>
       <id>sonarcloud-analysis</id>
       <properties>
-        <sonar.coverage.jacoco.xmlReportPaths>${project.reporting.outputDirectory}/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.reporting.outputDirectory}/jacoco/jacoco.xml
+        </sonar.coverage.jacoco.xmlReportPaths>
         <sonar.java.source>${maven.compiler.release}</sonar.java.source>
         <!-- Go to target/classes to avoid SonarCloud complaining about generated Java source code. -->
         <sonar.java.binaries>${project.build.outputDirectory}</sonar.java.binaries>

--- a/pom.xml
+++ b/pom.xml
@@ -2,59 +2,60 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <groupId>ai.timefold.solver.enterprise</groupId>
-    <artifactId>timefold-solver-enterprise-parent</artifactId>
-    <version>999-SNAPSHOT</version> <!-- Keep in sync with Community Edition. -->
-    <packaging>pom</packaging>
-    <name>Timefold Solver Enterprise Edition</name>
-    <description>
-        Timefold solves planning problems.
-        This lightweight, embeddable planning engine implements powerful and scalable algorithms
-        to optimize business resource scheduling and planning.
+  <groupId>ai.timefold.solver.enterprise</groupId>
+  <artifactId>timefold-solver-enterprise-parent</artifactId>
+  <version>999-SNAPSHOT</version> <!-- Keep in sync with Community Edition. -->
+  <packaging>pom</packaging>
+  <name>Timefold Solver Enterprise Edition</name>
+  <description>
+    Timefold solves planning problems.
+    This lightweight, embeddable planning engine implements powerful and scalable algorithms
+    to optimize business resource scheduling and planning.
 
-        This module is just the multiproject parent for the Enterprise Edition.
-        The planning engine itself is in timefold-solver-enterprise-core.
-    </description>
-    <url>https://timefold.ai</url>
-    <inceptionYear>2023</inceptionYear>
+    This module is just the multiproject parent for the Enterprise Edition.
+    The planning engine itself is in timefold-solver-enterprise-core.
+  </description>
+  <url>https://timefold.ai</url>
+  <inceptionYear>2023</inceptionYear>
 
-    <properties>
-        <enforcer.failOnDuplicatedClasses>false</enforcer.failOnDuplicatedClasses> <!-- Quarkus. -->
-    </properties>
+  <properties>
+    <enforcer.failOnDuplicatedClasses>false</enforcer.failOnDuplicatedClasses> <!-- Quarkus. -->
+  </properties>
 
-    <licenses>
-        <license>
-            <name>Timefold Commercial License</name>
-            <url>https://timefold.ai/company/contact/</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
+  <licenses>
+    <license>
+      <name>Timefold Commercial License</name>
+      <url>https://timefold.ai/company/contact/</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
 
-    <scm>
-        <connection>scm:git:git@github.com:TimefoldAI/timefold-solver-enterprise.git</connection>
-        <developerConnection>scm:git:git@github.com:TimefoldAI/timefold-solver-enterprise.git</developerConnection>
-        <url>https://github.com/TimefoldAI/timefold-solver-enterprise</url>
-    </scm>
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/TimefoldAI/timefold-solver-enterprise/issues/</url>
-    </issueManagement>
-    <developers>
-        <developer>
-            <name>Timefold Engineering</name>
-            <organization>Timefold</organization>
-            <organizationUrl>https://timefold.ai</organizationUrl>
-        </developer>
-    </developers>
+  <scm>
+    <connection>scm:git:git@github.com:TimefoldAI/timefold-solver-enterprise.git</connection>
+    <developerConnection>scm:git:git@github.com:TimefoldAI/timefold-solver-enterprise.git</developerConnection>
+    <url>https://github.com/TimefoldAI/timefold-solver-enterprise</url>
+  </scm>
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/TimefoldAI/timefold-solver-enterprise/issues/</url>
+  </issueManagement>
+  <developers>
+    <developer>
+      <name>Timefold Engineering</name>
+      <organization>Timefold</organization>
+      <organizationUrl>https://timefold.ai</organizationUrl>
+    </developer>
+  </developers>
 
-    <modules>
-        <module>build/bom</module>
-        <module>build/build-parent</module>
-        <module>core</module>
-        <module>quarkus</module>
-        <module>spring-boot</module>
-    </modules>
+  <modules>
+    <module>build/bom</module>
+    <module>build/build-parent</module>
+    <module>core</module>
+    <module>asm</module>
+    <module>quarkus</module>
+    <module>spring-boot</module>
+  </modules>
 
 </project>

--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>ai.timefold.solver.enterprise</groupId>
+    <artifactId>timefold-solver-enterprise-quarkus-parent</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>timefold-solver-enterprise-quarkus-deployment</artifactId>
+
+  <properties>
+    <java.module.name>ai.timefold.solver.enterprise.quarkus.deployment</java.module.name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>ai.timefold.solver</groupId>
+      <artifactId>timefold-solver-quarkus-deployment</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.timefold.solver.enterprise</groupId>
+      <artifactId>timefold-solver-enterprise-quarkus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.timefold.solver.enterprise</groupId>
+      <artifactId>timefold-solver-enterprise-asm</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.quarkus</groupId>
+              <artifactId>quarkus-extension-processor</artifactId>
+              <version>${version.io.quarkus}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- TODO enable dependency check later. -->
+            <id>analyze-only</id>
+            <configuration>
+              <failOnWarning>false</failOnWarning>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <version.io.quarkus>${version.io.quarkus}</version.io.quarkus>
+            <project.version>${project.version}</project.version>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/quarkus/deployment/src/main/java/ai/timefold/solver/enterprise/quarkus/deployment/TimefoldEnterpriseProcessor.java
+++ b/quarkus/deployment/src/main/java/ai/timefold/solver/enterprise/quarkus/deployment/TimefoldEnterpriseProcessor.java
@@ -1,0 +1,33 @@
+package ai.timefold.solver.enterprise.quarkus.deployment;
+
+import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
+import ai.timefold.solver.enterprise.asm.lambda.LambdaSharingEnhancer;
+
+import org.jboss.jandex.ClassInfo;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+public class TimefoldEnterpriseProcessor {
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem("timefold-solver-enterprise");
+    }
+
+    @BuildStep
+    void optimizeConstraintProvider(CombinedIndexBuildItem combinedIndex,
+            BuildProducer<BytecodeTransformerBuildItem> transformers) {
+        combinedIndex.getIndex().getAllKnownImplementors(ConstraintProvider.class)
+                .forEach(classInfo -> shareLambdas(classInfo, transformers));
+    }
+
+    private void shareLambdas(ClassInfo classInfo, BuildProducer<BytecodeTransformerBuildItem> transformers) {
+        transformers.produce(new BytecodeTransformerBuildItem.Builder()
+                .setClassToTransform(classInfo.name().toString())
+                .setInputTransformer(LambdaSharingEnhancer::shareLambdasInBytecode)
+                .build());
+    }
+}

--- a/quarkus/integration-test/pom.xml
+++ b/quarkus/integration-test/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>ai.timefold.solver.enterprise</groupId>
+    <artifactId>timefold-solver-enterprise-quarkus-parent</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>timefold-solver-enterprise-quarkus-integration-test</artifactId>
+
+  <properties>
+    <java.module.name>ai.timefold.solver.enterprise.quarkus</java.module.name>
+    <!-- Code of integration tests should not be a part of test coverage reports. -->
+    <sonar.coverage.exclusions>**/*</sonar.coverage.exclusions>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.timefold.solver.enterprise</groupId>
+      <artifactId>timefold-solver-enterprise-quarkus</artifactId>
+    </dependency>
+
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Transitive dependencies through quarkus are expected in this module. -->
+            <id>analyze-only</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>native</id>
+      <activation>
+        <property>
+          <name>native</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <skip>false</skip>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <systemPropertyVariables>
+                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+      </properties>
+    </profile>
+  </profiles>
+
+</project>

--- a/quarkus/integration-test/src/main/java/ai/timefold/solver/enterprise/quarkus/it/TimefoldEnterpriseTestResource.java
+++ b/quarkus/integration-test/src/main/java/ai/timefold/solver/enterprise/quarkus/it/TimefoldEnterpriseTestResource.java
@@ -1,0 +1,41 @@
+package ai.timefold.solver.enterprise.quarkus.it;
+
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import ai.timefold.solver.core.api.solver.SolverJob;
+import ai.timefold.solver.core.api.solver.SolverManager;
+import ai.timefold.solver.enterprise.quarkus.it.domain.TestdataStringLengthShadowEntity;
+import ai.timefold.solver.enterprise.quarkus.it.domain.TestdataStringLengthShadowSolution;
+
+@Path("/timefold/test")
+public class TimefoldEnterpriseTestResource {
+    @Inject
+    SolverManager<TestdataStringLengthShadowSolution, Long> solverManager;
+
+    @POST
+    @Path("/solver-factory")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String solveWithSolverFactory() {
+        TestdataStringLengthShadowSolution planningProblem = new TestdataStringLengthShadowSolution();
+        planningProblem.setEntityList(Arrays.asList(
+                new TestdataStringLengthShadowEntity(),
+                new TestdataStringLengthShadowEntity()));
+        planningProblem.setValueList(Arrays.asList("a", "bb", "ccc"));
+        SolverJob<TestdataStringLengthShadowSolution, Long> solverJob = solverManager.solve(1L, planningProblem);
+        try {
+            return solverJob.getFinalBestSolution().getScore().toString();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Solving was interrupted.", e);
+        } catch (ExecutionException e) {
+            throw new IllegalStateException("Solving failed.", e);
+        }
+    }
+}

--- a/quarkus/integration-test/src/main/java/ai/timefold/solver/enterprise/quarkus/it/domain/StringLengthVariableListener.java
+++ b/quarkus/integration-test/src/main/java/ai/timefold/solver/enterprise/quarkus/it/domain/StringLengthVariableListener.java
@@ -1,0 +1,58 @@
+package ai.timefold.solver.enterprise.quarkus.it.domain;
+
+import ai.timefold.solver.core.api.domain.variable.VariableListener;
+import ai.timefold.solver.core.api.score.director.ScoreDirector;
+
+public class StringLengthVariableListener
+        implements VariableListener<TestdataStringLengthShadowSolution, TestdataStringLengthShadowEntity> {
+
+    @Override
+    public void beforeEntityAdded(ScoreDirector<TestdataStringLengthShadowSolution> scoreDirector,
+            TestdataStringLengthShadowEntity entity) {
+        /* Nothing to do */
+    }
+
+    @Override
+    public void afterEntityAdded(ScoreDirector<TestdataStringLengthShadowSolution> scoreDirector,
+            TestdataStringLengthShadowEntity entity) {
+        /* Nothing to do */
+    }
+
+    @Override
+    public void beforeVariableChanged(ScoreDirector<TestdataStringLengthShadowSolution> scoreDirector,
+            TestdataStringLengthShadowEntity entity) {
+        /* Nothing to do */
+    }
+
+    @Override
+    public void afterVariableChanged(ScoreDirector<TestdataStringLengthShadowSolution> scoreDirector,
+            TestdataStringLengthShadowEntity entity) {
+        int oldLength = (entity.getLength() != null) ? entity.getLength() : 0;
+        int newLength = getLength(entity.getValue());
+        if (oldLength != newLength) {
+            scoreDirector.beforeVariableChanged(entity, "length");
+            entity.setLength(getLength(entity.getValue()));
+            scoreDirector.afterVariableChanged(entity, "length");
+        }
+    }
+
+    @Override
+    public void beforeEntityRemoved(ScoreDirector<TestdataStringLengthShadowSolution> scoreDirector,
+            TestdataStringLengthShadowEntity entity) {
+        /* Nothing to do */
+    }
+
+    @Override
+    public void afterEntityRemoved(ScoreDirector<TestdataStringLengthShadowSolution> scoreDirector,
+            TestdataStringLengthShadowEntity entity) {
+        /* Nothing to do */
+    }
+
+    private static int getLength(String value) {
+        if (value != null) {
+            return value.length();
+        } else {
+            return 0;
+        }
+    }
+}

--- a/quarkus/integration-test/src/main/java/ai/timefold/solver/enterprise/quarkus/it/domain/TestdataStringLengthShadowEntity.java
+++ b/quarkus/integration-test/src/main/java/ai/timefold/solver/enterprise/quarkus/it/domain/TestdataStringLengthShadowEntity.java
@@ -1,0 +1,37 @@
+package ai.timefold.solver.enterprise.quarkus.it.domain;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
+
+@PlanningEntity
+public class TestdataStringLengthShadowEntity {
+
+    @PlanningVariable(valueRangeProviderRefs = "valueRange")
+    private String value;
+
+    @ShadowVariable(variableListenerClass = StringLengthVariableListener.class,
+            sourceEntityClass = TestdataStringLengthShadowEntity.class, sourceVariableName = "value")
+    private Integer length;
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public Integer getLength() {
+        return length;
+    }
+
+    public void setLength(Integer length) {
+        this.length = length;
+    }
+
+}

--- a/quarkus/integration-test/src/main/java/ai/timefold/solver/enterprise/quarkus/it/domain/TestdataStringLengthShadowSolution.java
+++ b/quarkus/integration-test/src/main/java/ai/timefold/solver/enterprise/quarkus/it/domain/TestdataStringLengthShadowSolution.java
@@ -1,0 +1,49 @@
+package ai.timefold.solver.enterprise.quarkus.it.domain;
+
+import java.util.List;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
+
+@PlanningSolution
+public class TestdataStringLengthShadowSolution {
+
+    @ValueRangeProvider(id = "valueRange")
+    private List<String> valueList;
+    @PlanningEntityCollectionProperty
+    private List<TestdataStringLengthShadowEntity> entityList;
+
+    @PlanningScore
+    private HardSoftScore score;
+
+    // ************************************************************************
+    // Getters/setters
+    // ************************************************************************
+
+    public List<String> getValueList() {
+        return valueList;
+    }
+
+    public void setValueList(List<String> valueList) {
+        this.valueList = valueList;
+    }
+
+    public List<TestdataStringLengthShadowEntity> getEntityList() {
+        return entityList;
+    }
+
+    public void setEntityList(List<TestdataStringLengthShadowEntity> entityList) {
+        this.entityList = entityList;
+    }
+
+    public HardSoftScore getScore() {
+        return score;
+    }
+
+    public void setScore(HardSoftScore score) {
+        this.score = score;
+    }
+}

--- a/quarkus/integration-test/src/main/java/ai/timefold/solver/enterprise/quarkus/it/solver/TestdataStringLengthConstraintProvider.java
+++ b/quarkus/integration-test/src/main/java/ai/timefold/solver/enterprise/quarkus/it/solver/TestdataStringLengthConstraintProvider.java
@@ -1,0 +1,26 @@
+package ai.timefold.solver.enterprise.quarkus.it.solver;
+
+import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
+import ai.timefold.solver.core.api.score.stream.Constraint;
+import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
+import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
+import ai.timefold.solver.core.api.score.stream.Joiners;
+import ai.timefold.solver.enterprise.quarkus.it.domain.TestdataStringLengthShadowEntity;
+
+public class TestdataStringLengthConstraintProvider implements ConstraintProvider {
+
+    @Override
+    public Constraint[] defineConstraints(ConstraintFactory factory) {
+        return new Constraint[] {
+                factory.forEach(TestdataStringLengthShadowEntity.class)
+                        .join(TestdataStringLengthShadowEntity.class, Joiners.equal(TestdataStringLengthShadowEntity::getValue))
+                        .filter((a, b) -> a != b)
+                        .penalize(HardSoftScore.ONE_HARD)
+                        .asConstraint("Don't assign 2 entities the same value."),
+                factory.forEach(TestdataStringLengthShadowEntity.class)
+                        .reward(HardSoftScore.ONE_SOFT, TestdataStringLengthShadowEntity::getLength)
+                        .asConstraint("Maximize value length")
+        };
+    }
+
+}

--- a/quarkus/integration-test/src/main/resources/application.properties
+++ b/quarkus/integration-test/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+# The solver runs only for few milliseconds to avoid a HTTP timeout in this simple implementation.
+quarkus.timefold.solver.termination.best-score-limit=0hard/5soft

--- a/quarkus/integration-test/src/test/java/ai/timefold/solver/enterprise/quarkus/it/TimefoldEnterpriseTestResourceIT.java
+++ b/quarkus/integration-test/src/test/java/ai/timefold/solver/enterprise/quarkus/it/TimefoldEnterpriseTestResourceIT.java
@@ -1,0 +1,10 @@
+package ai.timefold.solver.enterprise.quarkus.it;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+/**
+ * Test various Timefold operations running in native mode
+ */
+@QuarkusIntegrationTest
+public class TimefoldEnterpriseTestResourceIT extends TimefoldEnterpriseTestResourceTest {
+}

--- a/quarkus/integration-test/src/test/java/ai/timefold/solver/enterprise/quarkus/it/TimefoldEnterpriseTestResourceTest.java
+++ b/quarkus/integration-test/src/test/java/ai/timefold/solver/enterprise/quarkus/it/TimefoldEnterpriseTestResourceTest.java
@@ -1,0 +1,28 @@
+package ai.timefold.solver.enterprise.quarkus.it;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+/**
+ * Test various Timefold operations running in Quarkus
+ */
+
+@QuarkusTest
+public class TimefoldEnterpriseTestResourceTest {
+    @Test
+    @Timeout(600)
+    void solveWithSolverFactory() throws Exception {
+        RestAssured.given()
+                .header("Content-Type", "application/json")
+                .when()
+                .post("/timefold/test/solver-factory")
+                .then()
+                .body(is(
+                        "0hard/5soft"));
+    }
+}

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -10,7 +10,8 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>timefold-solver-enterprise-quarkus</artifactId>
+  <artifactId>timefold-solver-enterprise-quarkus-parent</artifactId>
+  <packaging>pom</packaging>
 
   <name>Timefold Solver Enterprise Edition Quarkus integration</name>
   <description>
@@ -22,35 +23,15 @@
   </description>
   <url>https://timefold.ai</url>
 
-  <packaging>jar</packaging>
-
   <properties>
-    <java.module.name>ai.timefold.solver.enterprise.quarkus</java.module.name>
+    <!-- TODO Quarkus is riddled with duplicate classes, see https://github.com/quarkusio/quarkus/issues/9834 -->
+    <enforcer.failOnDuplicatedClasses>false</enforcer.failOnDuplicatedClasses>
   </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>ai.timefold.solver.enterprise</groupId>
-      <artifactId>timefold-solver-enterprise-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>ai.timefold.solver</groupId>
-      <artifactId>timefold-solver-quarkus</artifactId>
-    </dependency>
-  </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <ignoredUnusedDeclaredDependencies>
-            <dependency>ai.timefold.solver:*:jar</dependency>
-            <dependency>ai.timefold.solver.enterprise:*:jar</dependency>
-          </ignoredUnusedDeclaredDependencies>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+  <modules>
+    <module>runtime</module>
+    <module>deployment</module>
+    <module>integration-test</module>
+  </modules>
 
 </project>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>ai.timefold.solver.enterprise</groupId>
+    <artifactId>timefold-solver-enterprise-quarkus-parent</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>timefold-solver-enterprise-quarkus</artifactId>
+
+  <properties>
+    <java.module.name>ai.timefold.solver.enterprise.quarkus</java.module.name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>ai.timefold.solver.enterprise</groupId>
+      <artifactId>timefold-solver-enterprise-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.timefold.solver</groupId>
+      <artifactId>timefold-solver-quarkus</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <dependency>ai.timefold.solver:*:jar</dependency>
+            <dependency>ai.timefold.solver.enterprise:*:jar</dependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/quarkus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/quarkus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,15 @@
+---
+name: "Timefold Enterprise"
+metadata:
+  keywords:
+    - "timefold"
+    - "constraint-solver"
+    - "artificial-intelligence"
+    - "employee-rostering"
+    - "vehicle-routing-problem"
+    - "maintenance-scheduling"
+    - "timetabling"
+  #  guide: "https://quarkus.io/guides/timefold"
+  categories:
+    - "business-automation"
+  status: "stable"


### PR DESCRIPTION
Note: this moves the `timefold-solver-enterprise-quarkus` module from `quarkus` to `quarkus/runtime`, since we need a processor to transform the bytecode.